### PR TITLE
Revert "set migration parameters via configuration file"

### DIFF
--- a/uhyve-migration.c
+++ b/uhyve-migration.c
@@ -42,93 +42,7 @@ static struct sockaddr_in mig_server;
 static int com_sock = 0;
 static int listen_sock = 0;
 
-mig_params_t mig_params = {
-	.type = MIG_TYPE_COLD,
-	.mode = MIG_MODE_COMPLETE_DUMP,
-	.use_odp = false,
-	.prefetch = false,
-};
-
-/**
- * \brief Generates a setter for a migration parameter
- *
- * \param param The parameter that is to be set
- *
- * \param mig_param_str A string defining the respective migration parameter
- *
- */
-#define define_migration_param_setter(param)                                   \
-void                                                                           \
-set_migration_##param(const char *mig_param_str)                               \
-{                                                                              \
-	if (mig_param_str == NULL)                                             \
-		return;                                                        \
-                                                                               \
-	int i;                                                                 \
-	bool found_param = false;                                              \
-	for (i=0; i<sizeof(mig_##param##_conv)/sizeof(mig_##param##_conv[0]); ++i) { \
-		if (!strcmp (mig_param_str, mig_##param##_conv[i].str)) {      \
-			mig_params.param = mig_##param##_conv[i].mig_##param;\
-			found_param = true;                                    \
-		}                                                              \
-	}                                                                      \
-                                                                               \
-	if (!found_param) {                                                    \
-		/* we do not know this migration param */                      \
-		fprintf(stderr, "[ERROR] Migration ##param## '%s' not "        \
-				"supported. Fallback to default\n",            \
-				mig_param_str);                                \
-	}                                                                      \
-	return;                                                                \
-} \
-
-#define define_migration_param_getter(param)                                   \
-const char *                                                                         \
-get_migration_##param##_str(mig_##param##_t mig_##param)                       \
-{                                                                              \
-	return mig_##param##_conv[mig_##param].str;                            \
-} \
-
-/* define setter for migration parameters */
-define_migration_param_setter(type)
-define_migration_param_setter(mode)
-define_migration_param_getter(type)
-define_migration_param_getter(mode)
-
-/**
- * \brief prints the migration parameters
- */
-void
-print_migration_params(void)
-{
-	printf("========== MIGRATION PARAMETERS ==========\n");
-	printf("   MODE     : %s\n", get_migration_mode_str(mig_params.mode));
-	printf("   TYPE     : %s\n", get_migration_type_str(mig_params.type));
-	printf("   USE ODP  : %u\n", mig_params.use_odp);
-	printf("   PREFETCH : %u\n", mig_params.prefetch);
-	printf("==========================================\n");
-}
-
-/**
- * \brief Sets the migration parameters in accordance with a given file
- *
- * \param mig_param_file path to the file containing the migration parameters
- */
-void
-set_migration_params(const char *mig_param_filename)
-{
-	if (mig_param_filename == NULL)
-		return;
-
-	FILE *mig_param_file = fopen(mig_param_filename, "r");
-	char tmp_str[MAX_PARAM_STR_LEN];
-	fscanf(mig_param_file, "mode: %s\n", tmp_str);
-	set_migration_mode(tmp_str);
-	fscanf(mig_param_file, "type: %s\n", tmp_str);
-	set_migration_type(tmp_str);
-	fscanf(mig_param_file, "use-odp: %u\n", &mig_params.use_odp);
-	fscanf(mig_param_file, "prefetch: %u\n", &mig_params.prefetch);
-}
+static mig_type_t mig_type = MIG_TYPE_COLD;
 
 /**
  * \brief Returns the configured migration type
@@ -136,7 +50,35 @@ set_migration_params(const char *mig_param_filename)
 mig_type_t
 get_migration_type(void)
 {
-	return mig_params.type;
+	return mig_type;
+}
+
+/**
+ * \brief Sets the migration type
+ *
+ * \param mig_type_str A string defining the migration type
+ */
+void
+set_migration_type(const char *mig_type_str)
+{
+	if (mig_type_str == NULL)
+		return;
+
+	int i;
+	bool found_type = false;
+	for (i=0; i<sizeof(mig_type_conv)/sizeof(mig_type_conv[0]); ++i) {
+		if (!strcmp (mig_type_str, mig_type_conv[i].str)) {
+			mig_type = mig_type_conv[i].mig_type;
+			found_type = true;
+		}
+	}
+
+	/* we do not know this migration type */
+	if (!found_type) {
+		fprintf(stderr, "ERROR: Migration type '%s' not supported. Fallback to 'cold'\n", mig_type_str);
+	}
+
+	return;
 }
 
 /**
@@ -196,16 +138,12 @@ void connect_to_server(void)
 		exit(EXIT_FAILURE);
 	}
 
-	fprintf(stderr, "[INFO] Trying to connect to migration server: %s\n", buf);
+      	fprintf(stderr, "Trying to connect to migration server: %s\n", buf);
 	if (connect(com_sock, (struct sockaddr *)&mig_server, sizeof(mig_server)) < 0) {
 		perror("connect");
 		exit(EXIT_FAILURE);
     	}
-	fprintf(stderr, "[INFO] Successfully connected to: %s\n", buf);
-
-	/* send migration parameters */
-	res = send_data(&mig_params, sizeof(mig_params_t));
-	print_migration_params();
+      	fprintf(stderr, "Successfully connected to: %s\n", buf);
 }
 
 
@@ -221,7 +159,7 @@ void wait_for_client(uint16_t listen_portno)
 	struct sockaddr_in client_addr;
 
 	/* open migration socket */
-	fprintf(stderr, "[INFO] Waiting for incomming migration request ...\n");
+	fprintf(stderr, "Waiting for incomming migration request ...\n");
 	listen_sock = socket(AF_INET, SOCK_STREAM, 0);
 	memset(&serv_addr, '0', sizeof(serv_addr));
 
@@ -243,11 +181,7 @@ void wait_for_client(uint16_t listen_portno)
 		perror("inet_ntop");
 		exit(EXIT_FAILURE);
 	}
-	fprintf(stderr, "[INFO] Incomming migration from: %s\n", buf);
-
-	/* recv migration parameters */
-	res = recv_data(&mig_params, sizeof(mig_params_t));
-	print_migration_params();
+	fprintf(stderr, "Incomming migration from: %s\n", buf);
 }
 
 /**

--- a/uhyve-migration.h
+++ b/uhyve-migration.h
@@ -40,21 +40,11 @@ extern size_t guest_size;
 extern uint8_t* guest_mem;
 
 #define MIGRATION_PORT 1337
-#define MAX_PARAM_STR_LEN 128
 
 typedef enum {
-	MIG_MODE_COMPLETE_DUMP = 0,
+	MIG_MODE_COMPLETE_DUMP = 1,
 	MIG_MODE_INCREMENTAL_DUMP,
 } mig_mode_t;
-
-const static struct {
-	mig_mode_t mig_mode;
-	const char *str;
-} mig_mode_conv [] = {
-	{MIG_MODE_COMPLETE_DUMP, "complete-dump"},
-	{MIG_MODE_INCREMENTAL_DUMP, "incremental-dump"},
-};
-
 
 typedef enum {
 	MIG_TYPE_COLD = 0,
@@ -69,14 +59,6 @@ const static struct {
 	{MIG_TYPE_LIVE, "live"},
 };
 
-
-typedef struct _mig_params {
-	mig_type_t type;
-	mig_mode_t mode;
-	bool use_odp;
-	bool prefetch;
-} mig_params_t;
-
 typedef struct _mem_chunk {
 	size_t size;
 	uint8_t *ptr;
@@ -90,11 +72,7 @@ typedef struct _migration_metadata {
 	bool full_checkpoint;
 } migration_metadata_t;
 
-
-mig_params_t mig_params;
-
-void set_migration_params(const char *migration_param_filename);
-
+void set_migration_type(const char *mig_type_str);
 mig_type_t get_migration_type(void);
 
 void wait_for_client(uint16_t listen_portno);
@@ -105,7 +83,7 @@ void close_migration_channel(void);
 int recv_data(void *buffer, size_t length);
 int send_data(void *buffer, size_t length);
 
-void send_guest_mem(bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
+void send_guest_mem(mig_mode_t mode, bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
 void recv_guest_mem(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
 #endif /* __UHYVE_MIGRATION_H__ */
 

--- a/uhyve-x86_64.c
+++ b/uhyve-x86_64.c
@@ -828,7 +828,7 @@ void *migration_handler(void *arg)
 	if (get_migration_type() == MIG_TYPE_LIVE) {
 		/* resend rounds */
 		for (i=0; i<MIG_ITERS; ++i) {
-			send_guest_mem(0, mem_chunk_cnt, mem_chunks);
+			send_guest_mem(MIG_MODE_INCREMENTAL_DUMP, 0, mem_chunk_cnt, mem_chunks);
 		}
 	}
 
@@ -840,7 +840,7 @@ void *migration_handler(void *arg)
 	pthread_barrier_wait(&migration_barrier);
 
 	/* send the final dump */
-	send_guest_mem(1, mem_chunk_cnt, mem_chunks);
+	send_guest_mem(MIG_MODE_INCREMENTAL_DUMP, 1, mem_chunk_cnt, mem_chunks);
 	fprintf(stderr, "Memory sent! (Guest size: %zu bytes)\n", guest_size);
 
 	/* free mem_chunk info */

--- a/uhyve.c
+++ b/uhyve.c
@@ -749,7 +749,7 @@ int uhyve_loop(int argc, char **argv)
 {
 	const char* hermit_check = getenv("HERMIT_CHECKPOINT");
 	const char* hermit_mig_support = getenv("HERMIT_MIGRATION_SUPPORT");
-	const char* hermit_mig_params = getenv("HERMIT_MIGRATION_PARAMS");
+	const char* hermit_mig_type = getenv("HERMIT_MIGRATION_TYPE");
 	const char* hermit_debug = getenv("HERMIT_DEBUG");
 	int ts = 0, i = 0;
 
@@ -786,7 +786,7 @@ int uhyve_loop(int argc, char **argv)
 
 	if (hermit_mig_support) {
 		set_migration_target(hermit_mig_support, MIGRATION_PORT);
-		set_migration_params(hermit_mig_params);
+		set_migration_type(hermit_mig_type);
 
 		/* block SIGUSR1 in main thread */
 		sigemptyset (&signal_mask);


### PR DESCRIPTION
My mistake, I oversaw a compiler errors. Could you check the current version of hermit-caves with you patch?