### PR TITLE
Accelerate cold-migration using the alloc_list

### DIFF
--- a/uhyve-migration.h
+++ b/uhyve-migration.h
@@ -82,6 +82,11 @@ typedef struct _mem_chunk {
 	uint8_t *ptr;
 } mem_chunk_t;
 
+typedef struct _mem_mappings {
+	mem_chunk_t *mem_chunks;
+	size_t count;
+} mem_mappings_t;
+
 typedef struct _migration_metadata {
 	uint32_t ncores;
 	size_t guest_size;
@@ -99,11 +104,13 @@ mig_type_t get_migration_type(void);
 
 void wait_for_client(uint16_t listen_portno);
 void set_migration_target(const char *ip_str, int port);
-void connect_to_server(void);
+int connect_to_server(void);
 void close_migration_channel(void);
 
 int recv_data(void *buffer, size_t length);
 int send_data(void *buffer, size_t length);
+
+void request_mem_mappings(void);
 
 void send_guest_mem(bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
 void recv_guest_mem(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);

--- a/uhyve.h
+++ b/uhyve.h
@@ -44,6 +44,8 @@
 #define UHYVE_PORT_NETREAD              0x680
 #define UHYVE_PORT_NETSTAT              0x700
 
+#define UHYVE_PORT_ALLOCLIST 		0x720
+
 /* Ports and data structures for uhyve command line arguments and envp
  * forwarding */
 #define UHYVE_PORT_CMDSIZE		0x740
@@ -51,7 +53,9 @@
 
 #define UHYVE_UART_PORT			0x800
 
-#define UHYVE_IRQ       11
+#define UHYVE_IRQ_BASE            11
+#define UHYVE_IRQ_NET             (UHYVE_IRQ_BASE+0)
+#define UHYVE_IRQ_MIGRATION       (UHYVE_IRQ_BASE+1)
 
 #define SIGTHRCHKP 	(SIGRTMIN+0)
 #define SIGTHRMIG 	(SIGRTMIN+1)


### PR DESCRIPTION
This patch relies on HermitCore/libhermit#100 to accelerate the cold-migration using a list of allocated memory areas. This avoids the unnecessary registration of the whole guest's physical memory to the HCA.