### PR TITLE
cleanup the migration code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_RDMA_MIGRATION)
 	set(SRC ${SRC} uhyve-migration-rdma.c)
 else()
 	remove_definitions(-D__RDMA_MIGRATION__)
+	set(SRC ${SRC} uhyve-migration-tcp.c)
 endif()
 
 check_include_files(asm/msr-index.h HAVE_MSR_INDEX_H)

--- a/uhyve-migration-rdma.c
+++ b/uhyve-migration-rdma.c
@@ -45,6 +45,8 @@
 
 #ifdef __RDMA_MIGRATION__
 
+#define MIG_ITERS 		(4)
+
 #define IB_CQ_ENTRIES 		(1)
 #define IB_MAX_INLINE_DATA 	(0)
 #define IB_MAX_DEST_RD_ATOMIC 	(1)
@@ -137,14 +139,14 @@ void print_send_wr_info(uint64_t id)
  * state ready to be connected with the remote side.
  */
 static void
-init_com_hndl(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks, bool sender)
+init_com_hndl(mem_mappings_t mem_mappings, bool sender)
 {
 	/* initialize com_hndl */
 	memset(&com_hndl, 0, sizeof(com_hndl));
 
 	/* the guest physical memory is the communication buffer */
 	com_hndl.buf = guest_mem;
-	com_hndl.mr_cnt = mem_chunk_cnt;
+	com_hndl.mr_cnt = mem_mappings.count;
 
 	struct ibv_device **device_list = NULL;
 	int num_devices = 0;
@@ -263,20 +265,22 @@ init_com_hndl(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks, bool sender)
 	}
 
 	for (i=0; i<com_hndl.mr_cnt; ++i) {
+		/* register memory region */
 		if ((com_hndl.mrs[i] = ibv_reg_mr(com_hndl.pd,
-						mem_chunks[i].ptr,
-						mem_chunks[i].size,
+						mem_mappings.mem_chunks[i].ptr,
+						mem_mappings.mem_chunks[i].size,
 						access_flags)) == NULL) {
 			fprintf(stderr,
 				"[ERROR] Could not register the memory region #%d (ptr: %llx; size: %llu) "
 				"- %d (%s). Abort!\n",
 				i,
-				mem_chunks[i].ptr,
-				mem_chunks[i].size,
+				mem_mappings.mem_chunks[i].ptr,
+				mem_mappings.mem_chunks[i].size,
 				errno,
 				strerror(errno));
 			exit(EXIT_FAILURE);
 		}
+
 		fprintf(stderr, "[INFO] com_hndl.mrs[%d]->addr = 0x%llx; com_hndl->mrs[%d].length = %llu\n",
 				i,
 				com_hndl.mrs[i]->addr,
@@ -507,6 +511,73 @@ con_com_buf(void) {
 }
 
 /**
+ * \brief Returns the index of the MR enclosing a given mem_chunk
+ */
+static inline ssize_t
+determine_enclosing_mr(void *ptr)
+{
+	size_t i = 0;
+	ssize_t res = -1;
+	for (i=0; i<com_hndl.mr_cnt; ++i) {
+		size_t cur_mr_start = (size_t)com_hndl.mrs[i]->addr;
+		size_t cur_mr_end = cur_mr_start+com_hndl.mrs[i]->length;
+		if ((cur_mr_start <= (size_t)ptr) &&
+		    (cur_mr_end > (size_t)ptr)) {
+			res = i;
+			break;
+		}
+	}
+
+	return res;
+}
+
+
+/**
+ * \brief Prefetches a given list of memory mappings
+ */
+static void
+prefetch_mem_mappings(mem_mappings_t mem_mappings)
+{
+	int i, j, ret;
+	for (i=0; i<mem_mappings.count; ++i) {
+		void *cur_ptr = mem_mappings.mem_chunks[i].ptr;
+		size_t cur_size = mem_mappings.mem_chunks[i].size;
+
+		/* find enclosing MR
+		 * -> assumption: a mapping with always fit within an MR
+		 */
+		ssize_t mr_num = 0;
+		if (determine_enclosing_mr(cur_ptr) < 0) {
+			fprintf(stderr,
+				"[WARNING] Could not determine encloding MR "
+				"for ptr: 0x%llx size: 0x%llx.\n",
+				cur_ptr,
+				cur_size);
+			return;
+		}
+
+		/* prefetch the memory chunk */
+		struct ibv_exp_prefetch_attr prefetch_attr = {
+			.flags 		= IBV_EXP_PREFETCH_WRITE_ACCESS,
+			.addr 		= cur_ptr,
+			.length 	= cur_size,
+			.comp_mask 	= 0,
+		};
+		if ((ret = ibv_exp_prefetch_mr(com_hndl.mrs[mr_num],
+						&prefetch_attr)) < 0) {
+			fprintf(stderr,
+				"[WARNING] Could not prefetch within MR #%d - "
+				"result %d - %d (%s).\n",
+				i,
+				ret,
+				errno,
+				strerror(errno));
+		}
+	}
+}
+
+
+/**
  * \brief Set the destination node for a migration
  *
  * \param ip_str a string containing the IPv4 addr of the destination
@@ -585,6 +656,27 @@ prepare_send_list_elem(void)
 }
 
 /**
+ * \brief Appends an 'ibv_send_wr' to the send_list
+ *
+ * \param send_wr WR to be appended to the send_list
+ */
+static inline void
+append_to_send_list(struct ibv_send_wr *send_wr)
+{
+	if (send_list == NULL) {
+		send_list = send_list_last = send_wr;
+	} else {
+		send_list_last->next = send_wr;
+		send_list_last = send_list_last->next;
+	}
+
+	/* we have to request a CQE if max_send_wr is reached to avoid overflows */
+	if ((++send_list_length%IB_MAX_SEND_WR) == 0) {
+		send_list_last->send_flags 	= IBV_SEND_SIGNALED;
+	}
+}
+
+/**
  * \brief Creates an 'ibv_send_wr' and appends it to the send_list
  *
  * \param addr the page table entry of the memory page
@@ -639,7 +731,7 @@ create_send_list_entry (void *addr, size_t addr_size, void *page, size_t page_si
 
 	/* did we find the correct memory region? */
 	if (i == com_hndl.mr_cnt) {
-		fprintf(stderr, "[ERROR] Could not find a valid MR for address 0x%llx!\n", page);
+		fprintf(stderr, "[ERROR] Could not find a valid MR for address 0x%llx! (send_list_length = %llu)\n", page, send_list_length);
 		return;
 	}
 
@@ -651,18 +743,82 @@ create_send_list_entry (void *addr, size_t addr_size, void *page, size_t page_si
 	}
 
 	/* apped work request to send list */
-	if (send_list == NULL) {
-		send_list = send_list_last = send_wr;
-	} else {
-		send_list_last->next = send_wr;
-		send_list_last = send_list_last->next;
-	}
-	/* we have to request a CQE if max_send_wr is reached to avoid overflows */
-	if ((++send_list_length%IB_MAX_SEND_WR) == 0) {
-		send_list_last->send_flags 	= IBV_SEND_SIGNALED;
-	}
+	append_to_send_list(send_wr);
 }
 
+/**
+ * \brief Frees the send list
+ */
+static inline
+void cleanup_send_list(void)
+{
+	struct ibv_send_wr *cur_send_wr = send_list;
+	struct ibv_send_wr *tmp_send_wr = NULL;
+	while (cur_send_wr != NULL) {
+		free(cur_send_wr->sg_list);
+		tmp_send_wr = cur_send_wr;
+		cur_send_wr = cur_send_wr->next;
+		free(tmp_send_wr);
+	}
+	send_list_length = 0;
+}
+
+/*
+ * \brief Processes the send list by passing the send_wrs to the HCA
+ */
+static inline
+void process_send_list(void)
+{
+	/* we have to call ibv_post_send() as long as 'send_list' contains elements  */
+	struct ibv_wc wc;
+	struct ibv_send_wr *remaining_send_wr = NULL;
+	do {
+		/* send data */
+		remaining_send_wr = NULL;
+		if (ibv_post_send(com_hndl.qp, send_list, &remaining_send_wr) && (errno != ENOMEM)) {
+			fprintf(stderr,
+				"[ERROR] Could not post send - %d (%s). Abort!\n",
+				errno,
+				strerror(errno));
+			exit(EXIT_FAILURE);
+		}
+
+		/* wait for send WRs if CQ is full */
+		int res = 0;
+		do {
+			if ((res = ibv_poll_cq(com_hndl.cq, 1, &wc)) < 0) {
+				fprintf(stderr,
+					"[ERROR] Could not poll on CQ - %d (%s). Abort!\n",
+					errno,
+					strerror(errno));
+				exit(EXIT_FAILURE);
+			}
+		} while (res < 1);
+		if (wc.status != IBV_WC_SUCCESS) {
+			fprintf(stderr,
+			    "[ERROR] WR failed status %s (%d) for wr_id %llu\n",
+			    ibv_wc_status_str(wc.status),
+			    wc.status,
+			    wc.wr_id);
+
+			print_send_wr_info(wc.wr_id);
+		}
+		send_list = remaining_send_wr;
+	} while (remaining_send_wr);
+
+
+	/* ensure that we receive the CQE for the last page */
+	if (wc.wr_id != IB_WR_WRITE_LAST_PAGE_ID) {
+		fprintf(stderr,
+		    "[ERROR] WR failed status %s (%d) for wr_id %d\n",
+		    ibv_wc_status_str(wc.status),
+		    wc.status,
+		    (int)wc.wr_id);
+	}
+
+	/* free send list */
+	cleanup_send_list();
+}
 
 /**
  * \brief Prepares a send_list containing all memory defined by com_hndl.mrs
@@ -699,121 +855,124 @@ void enqueue_all_mrs(void)
 	}
 }
 
+/**
+ * \brief A simple termination criterion for the live-migration
+ */
+static inline
+bool termination_criterion(void)
+{
+	/* use a simple counter */
+	static uint32_t mig_round = 0;
+
+	return (mig_round++ == MIG_ITERS)? true : false;
+}
+
 
 /**
- * \brief Sends the guest memory to the destination
+ * \brief The pre-copy phase of the live-migration
  *
- * \param final_dump last dump of a live migration
- * \param mem_chunk_cnt number of memory chunks to be registered
- * \param mem_chunks an array of memory chunks to be registered
+ * \param guest_mem the guest physical memory
+ * \param mem_mappings the mapped memory regions
+ *
+ * This function initializes the IB connection and executes the precopy
+ * iteration steps.
  */
-void send_guest_mem(bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chunks)
+void precopy_phase(mem_mappings_t guest_mem, mem_mappings_t mem_mappings)
+{
+	/* the live migration needs the whole guest memory to be registered */
+	if ((mig_params.type == MIG_TYPE_LIVE) || (mem_mappings.count == 0)) {
+		init_com_hndl(guest_mem, true);
+	} else {
+		init_com_hndl(mem_mappings, true);
+	}
+
+	/* prefetch allocated regions if ODP is used */
+	if (mig_params.use_odp && mig_params.prefetch) {
+		prefetch_mem_mappings(mem_mappings);
+
+		/* disable prefetching for cold/complete migration */
+		if ((mig_params.mode == MIG_MODE_COMPLETE_DUMP) ||
+			(mig_params.type == MIG_TYPE_COLD)) {
+				mig_params.prefetch = false;
+			}
+	}
+
+	/* establish the IB connection */
+	exchange_qp_info(false);
+	con_com_buf();
+
+	/* perform pre-copy iterations */
+	while (!(mig_params.type == MIG_TYPE_COLD) && !termination_criterion()) {
+		/* iterate guest page tables
+		 * -> ignore migration mode
+		 * -> enforce INCREMENTAL dumps
+		 */
+		determine_dirty_pages(create_send_list_entry);
+
+		/* is there anything to send? */
+		if (send_list_length != 0) {
+			/* we want a CQE for the last WR */
+			send_list_last->wr_id 		= IB_WR_WRITE_LAST_PAGE_ID;
+			send_list_last->send_flags 	= IBV_SEND_SIGNALED;
+
+			process_send_list();
+		} else {
+			break;
+		}
+
+	}
+
+	return;
+}
+
+
+/**
+ * \brief The stop-and-copy phase of the live-migration
+ *
+ * This function performs the last step of the migration. After freezing the
+ * VCPUs the guest-physical memory is transferred (another time) to the
+ * destination.
+ */
+void stop_and_copy_phase(void)
 {
 	int res = 0, i = 0;
 	static bool ib_initialized = false;
 
-	/* prepare IB channel */
-	if (!ib_initialized) {
-		init_com_hndl(mem_chunk_cnt, mem_chunks, true);
-		exchange_qp_info(false);
-		con_com_buf();
-
-		ib_initialized = true;
-	}
 
 	/* determine migration mode */
-	switch (mig_params.mode) {
-	case MIG_MODE_COMPLETE_DUMP:
-		enqueue_all_mrs();
-		break;
-	case MIG_MODE_INCREMENTAL_DUMP:
-		/* iterate guest page tables */
+	if (mig_params.type == MIG_TYPE_COLD) {
+		switch (mig_params.mode) {
+		case MIG_MODE_COMPLETE_DUMP:
+			enqueue_all_mrs();
+			break;
+		case MIG_MODE_INCREMENTAL_DUMP:
+			/* iterate guest page tables */
+			determine_dirty_pages(create_send_list_entry);
+			break;
+		default:
+			fprintf(stderr, "[ERROR] Unknown migration mode. Abort!\n");
+			exit(EXIT_FAILURE);
+		}
+	} else if (mig_params.type == MIG_TYPE_LIVE) {
 		determine_dirty_pages(create_send_list_entry);
-		break;
-	default:
-		fprintf(stderr, "[ERROR] Unknown migration mode. Abort!\n");
+	} else {
+		fprintf(stderr, "[ERROR] Unknown migration type. Abort!\n");
 		exit(EXIT_FAILURE);
 	}
 
-	/* create a dumy WR request if there is nothing to send */
-	if (send_list_length == 0)
-		create_send_list_entry(NULL, 0, NULL, 0);
+	/* create a dumy WR request if there is nothing to be sent */
+	if (send_list_length == 0) {
+		struct ibv_send_wr *send_wr =  prepare_send_list_elem();
+		append_to_send_list(send_wr);
+	}
 
 	/* we have to wait for the last WR before informing dest */
-	if ((mig_params.mode == MIG_MODE_COMPLETE_DUMP) || final_dump) {
-		send_list_last->wr_id 		= IB_WR_WRITE_LAST_PAGE_ID;
-		send_list_last->opcode 		= IBV_WR_RDMA_WRITE_WITH_IMM;
-		send_list_last->send_flags 	= IBV_SEND_SIGNALED | IBV_SEND_SOLICITED;
-		send_list_last->imm_data 	= htonl(0x1);
-	} else {
-		send_list_last->wr_id 		= IB_WR_WRITE_LAST_PAGE_ID;
-		send_list_last->send_flags 	= IBV_SEND_SIGNALED;
-	}
+	send_list_last->wr_id 		= IB_WR_WRITE_LAST_PAGE_ID;
+	send_list_last->opcode 		= IBV_WR_RDMA_WRITE_WITH_IMM;
+	send_list_last->send_flags 	= IBV_SEND_SIGNALED | IBV_SEND_SOLICITED;
+	send_list_last->imm_data 	= htonl(0x1);
 
-	printf("[DEBUG] Send list length %d\n", send_list_length);
-
-	/* we have to call ibv_post_send() as long as 'send_list' contains elements  */
- 	struct ibv_wc wc;
-	struct ibv_send_wr *remaining_send_wr = NULL;
-	do {
-		/* send data */
-		remaining_send_wr = NULL;
-		if (ibv_post_send(com_hndl.qp, send_list, &remaining_send_wr) && (errno != ENOMEM)) {
-			fprintf(stderr,
-				"[ERROR] Could not post send"
-				"- %d (%s). Abort!\n",
-				errno,
-				strerror(errno));
-			exit(EXIT_FAILURE);
-		}
-
-		/* wait for send WRs if CQ is full */
-		do {
-			if ((res = ibv_poll_cq(com_hndl.cq, 1, &wc)) < 0) {
-				fprintf(stderr,
-					"[ERROR] Could not poll on CQ"
-					"- %d (%s). Abort!\n",
-					errno,
-					strerror(errno));
-				exit(EXIT_FAILURE);
-			}
-		} while (res < 1);
-		if (wc.status != IBV_WC_SUCCESS) {
-			fprintf(stderr,
-			    "[ERROR] WR failed status %s (%d) for wr_id %llu\n",
-			    ibv_wc_status_str(wc.status),
-			    wc.status,
-			    wc.wr_id);
-
-			print_send_wr_info(wc.wr_id);
-		}
-		send_list = remaining_send_wr;
-	} while (remaining_send_wr);
-
-
-	/* ensure that we receive the CQE for the last page */
-	if (wc.wr_id != IB_WR_WRITE_LAST_PAGE_ID) {
-		fprintf(stderr,
-		    "[ERROR] WR failed status %s (%d) for wr_id %d\n",
-		    ibv_wc_status_str(wc.status),
-		    wc.status,
-		    (int)wc.wr_id);
-	}
-
-	/* cleanup send_list */
-	struct ibv_send_wr *cur_send_wr = send_list;
-	struct ibv_send_wr *tmp_send_wr = NULL;
-	while (cur_send_wr != NULL) {
-		free(cur_send_wr->sg_list);
-		tmp_send_wr = cur_send_wr;
-		cur_send_wr = cur_send_wr->next;
-		free(tmp_send_wr);
-	}
-	send_list_length = 0;
-
-	/* do not close the channel in a pre-dump */
-	if (!final_dump)
-		return;
+	process_send_list();
 
 	/* free IB-related resources */
 	destroy_com_hndl();
@@ -829,13 +988,15 @@ void send_guest_mem(bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chun
  *
  * The receive participates in the IB connection setup and waits for the
  * 'solicited' event sent with the last WR issued by the sender.
+ *
+ * \param mem_mappings the memory regions regions that have to be mapped
  */
-void recv_guest_mem(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks)
+void recv_guest_mem(mem_mappings_t mem_mappings)
 {
 	int res = 0;
 
 	/* prepare IB channel */
-	init_com_hndl(mem_chunk_cnt, mem_chunks, false);
+	init_com_hndl(mem_mappings, false);
 	exchange_qp_info(true);
 	con_com_buf();
 

--- a/uhyve-migration-tcp.c
+++ b/uhyve-migration-tcp.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018, Simon Pickartz, RWTH Aachen University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+#include <infiniband/verbs_exp.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+#include "uhyve-migration.h"
+#include "uhyve.h"
+
+
+#ifndef __RDMA_MIGRATION__
+
+extern mem_mappings_t mem_mappings;
+
+static mem_mappings_t mappings_to_be_transferred = {NULL, 0};
+
+void precopy_phase(mem_mappings_t guest_mem, mem_mappings_t mem_mappings)
+{
+	/* TODO: implement live-migration */
+	if (mig_params.type == MIG_TYPE_LIVE) {
+		fprintf(stderr, "[WARNING] Live-migration currently not "
+				"supported via TCP/IP. Fallback to "
+				"cold-migration!\n");
+		mappings_to_be_transferred = guest_mem;
+	} else {
+		mappings_to_be_transferred = mem_mappings;
+	}
+
+	return;
+}
+
+void stop_and_copy_phase(void)
+{
+	/* determine migration mode */
+	switch (mig_params.mode) {
+	case MIG_MODE_INCREMENTAL_DUMP:
+		fprintf(stderr, "[WARNING] Incremental dumps currently not "
+				"supported via TCP/IP. Fallback to complete "
+				"dump!\n");
+	case MIG_MODE_COMPLETE_DUMP: {
+		size_t i = 0;
+		for (i=0; i<mappings_to_be_transferred.count; ++i) {
+			send_data(mappings_to_be_transferred.mem_chunks[i].ptr,
+				  mappings_to_be_transferred.mem_chunks[i].size);
+		}
+		break;
+	}
+	default:
+		fprintf(stderr, "ERROR: Unknown migration mode. Abort!\n");
+		exit(EXIT_FAILURE);
+	}
+
+	fprintf(stderr, "Guest memory sent!\n");
+}
+
+void recv_guest_mem(mem_mappings_t mem_mappings)
+{
+	size_t i = 0;
+	for (i=0; i<mem_mappings.count; ++i) {
+		recv_data(mem_mappings.mem_chunks[i].ptr, mem_mappings.mem_chunks[i].size);
+	}
+	fprintf(stderr, "Guest memory received!\n");
+}
+#endif /* __RDMA_MIGRATION__ not defined */

--- a/uhyve-migration.h
+++ b/uhyve-migration.h
@@ -110,11 +110,11 @@ void close_migration_channel(void);
 int recv_data(void *buffer, size_t length);
 int send_data(void *buffer, size_t length);
 
-void generate_mem_mappings(void);
+void send_mem_regions(mem_mappings_t guest_physical_memory, mem_mappings_t mem_mappings);
+void recv_mem_regions(mem_mappings_t *mem_mappings);
 
-void send_guest_mem(bool final_dump, size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
-void recv_guest_mem(size_t mem_chunk_cnt, mem_chunk_t *mem_chunks);
+void precopy_phase(mem_mappings_t guest_mem, mem_mappings_t mem_mappings);
+void stop_and_copy_phase(void);
+void recv_guest_mem(mem_mappings_t mem_mappings);
 #endif /* __UHYVE_MIGRATION_H__ */
-
-
 

--- a/uhyve.h
+++ b/uhyve.h
@@ -111,6 +111,7 @@ typedef struct _migration_metadata migration_metadata_t;
 void print_registers(void);
 void timer_handler(int signum);
 void *migration_handler(void *arg);
+void determine_guest_allocations(void);
 void restore_cpu_state(vcpu_state_t cpu_state);
 vcpu_state_t read_cpu_state(void);
 vcpu_state_t save_cpu_state(void);


### PR DESCRIPTION
* The live-migration logic now resides within the migration module
* Move TCP migration to separate file (only cold-migration support!)

The RDMA migration implements the following control flow:
![image](https://user-images.githubusercontent.com/2814914/45218666-b83c2780-b2a8-11e8-8434-3fde506139ab.png)
