### PR TITLE
This is the first implementation of the uhyve-monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,15 @@ option(ENABLE_RDMA_MIGRATION "Migration support via RDMA" OFF)
 
 add_compile_options(-std=c99)
 
-list(APPEND LIBS "-pthread")
+list(APPEND LIBS "-pthread" "-levent" "-levent_pthreads" "-lm")
 set(SRC proxy.c
 	utils.c
 	uhyve.c
+	uhyve-checkpoint.c
 	uhyve-net.c
 	uhyve-migration.c
+	uhyve-monitor.c
+	uhyve-json.c
 	uhyve-x86_64.c
 	uhyve-aarch64.c
 	uhyve-gdb.c

--- a/uhyve-aarch64.c
+++ b/uhyve-aarch64.c
@@ -265,7 +265,7 @@ void write_cpu_state(void)
 	err(1, "Checkpointing is currently not supported!");
 }
 
-int load_checkpoint(uint8_t* mem, char* path)
+int load_checkpoint(FILE *f, const bool last_checkpoint)
 {
 	err(1, "Checkpointing is currently not supported!");
 }

--- a/uhyve-checkpoint.c
+++ b/uhyve-checkpoint.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2018, RWTH Aachen University
+ * Author(s): Stefan Lankes <slankes@eonerc.rwth-aachen.de>
+ *            Simon Pickartz <spickartz@eonerc.rwth-aachen.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+
+#define MAX_FNAME (256)
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+
+#include "uhyve-checkpoint.h"
+#include "uhyve.h"
+
+extern pthread_barrier_t barrier;
+extern uint32_t          ncores;
+extern uint8_t *         guest_mem;
+extern uint64_t          elf_entry;
+extern uint32_t          no_checkpoint;
+extern bool              full_checkpoint;
+extern size_t            guest_size;
+extern char *            guest_path;
+extern int               kvm, vmfd, netfd, efd, mig_efd;
+extern pthread_t *       vcpu_threads;
+extern bool              verbose;
+
+static FILE *chk_file = NULL;
+static char *chk_path = NULL;
+
+/**
+ * \brief Opens the checkpoint file for writing
+ *
+ * \param path The path to the checkpoint directory
+ */
+static void
+open_chk_file(char *path)
+{
+	char fname[MAX_FNAME];
+	snprintf(fname, MAX_FNAME, "%s/chk%u_mem.dat", path, no_checkpoint);
+	chk_file = fopen(fname, "w");
+	if (chk_file == NULL) {
+		err(1, "fopen: unable to open file");
+	}
+}
+
+/**
+ * \brief Closes the checkpoint file
+ */
+static void
+close_chk_file(void)
+{
+	fclose(chk_file);
+}
+
+/**
+ * \brief Writes a memory location to the checkpoint file
+ *
+ * \param addr The memory location to be written to the file
+ * \param bytes The amount of bytes to be written
+ */
+static void
+write_chk_file(void *addr, size_t bytes)
+{
+	if (fwrite(addr, bytes, 1, chk_file) != 1) {
+		err(1, "fwrite failed");
+	}
+}
+
+/**
+ * \brief Writes a memory page to the checkpoint file
+ *
+ * \param entry A pointer to the page table entry
+ * \param entry_size The size of the page table entry
+ * \param page A pointer to the memory page
+ * \param page_size The size of the memory page
+ */
+static void
+write_mem_page_to_chk_file(void *entry, size_t entry_size, void *page,
+			   size_t page_size)
+{
+	write_chk_file(entry, entry_size);
+	write_chk_file(page, page_size);
+}
+
+/**
+ * \brief Load the checkpoint configuration file
+ *
+ * \param chk_path Path to the checkpoint directory
+ *
+ * This function reads the checkpoint configuration from the 'chk_config.txt'
+ * within the given checkpoint directory.
+ *
+ * TODO: use json instead of plain text file
+ */
+int32_t
+load_checkpoint_config(const char *chk_path)
+{
+	int  tmp = 0;
+	char chk_config_name[MAX_FNAME];
+	snprintf(chk_config_name, MAX_FNAME, "%s/chk_config.txt", chk_path);
+	FILE *f = fopen(chk_config_name, "r");
+
+	if (f == NULL)
+		return -1;
+
+	guest_path = (char *)malloc(MAX_FNAME);
+	fscanf(f, "application path: %s\n", guest_path);
+	fscanf(f, "number of cores: %u\n", &ncores);
+	fscanf(f, "memory size: 0x%zx\n", &guest_size);
+	fscanf(f, "checkpoint number: %u\n", &no_checkpoint);
+	fscanf(f, "entry point: 0x%zx", &elf_entry);
+	fscanf(f, "full checkpoint: %d", &tmp);
+	full_checkpoint = tmp ? true : false;
+
+	fclose(f);
+
+	return 0;
+}
+
+/**
+ * \brief The checkpoint handler for the VCPUs
+ *
+ * This handler calls the architecture-specific method to store the VCPU state.
+ */
+void
+vcpu_thread_chk_handler(int signum)
+{
+	pthread_barrier_wait(&barrier);
+	write_cpu_state(chk_path);
+	pthread_barrier_wait(&barrier);
+}
+
+/**
+ * \brief Create a checkpoint
+ *
+ * \param path The directory where the checkpoint should be stored
+ * \param full_checkpoint Make a complete dump of the guest memory
+ *
+ * This function actually creates a checkpoint and writes it to the hard disk.
+ * TODO: determine checkpoint number from given directory
+ */
+void
+create_checkpoint(char *path, bool full_checkpoint)
+{
+	struct stat    st = {0};
+	struct timeval begin, end;
+
+	if (verbose)
+		gettimeofday(&begin, NULL);
+
+	// create the checkpoint directory
+	if (stat(path, &st) == -1)
+		mkdir(path, 0700);
+
+	// Request the VCPUs to write their CPU state
+	chk_path = path;
+	for (size_t i = 0; i < ncores; i++)
+		if (vcpu_threads[i] != pthread_self())
+			pthread_kill(vcpu_threads[i], SIGTHRCHKP);
+
+	// Request the VCPUs to write their state to the hard disk
+	pthread_barrier_wait(&barrier);
+	write_cpu_state(chk_path);
+
+	// Open the checkpoint file for the memor content
+	open_chk_file(path);
+
+	/*
+	struct kvm_irqchip irqchip = {};
+	if (cap_irqchip)
+		kvm_ioctl(vmfd, KVM_GET_IRQCHIP, &irqchip);
+	else
+		memset(&irqchip, 0x00, sizeof(irqchip));
+	if (fwrite(&irqchip, sizeof(irqchip), 1, f) != 1)
+		err(1, "fwrite failed");
+	*/
+
+	// Write the guest clock
+	struct kvm_clock_data clock = {};
+	kvm_ioctl(vmfd, KVM_GET_CLOCK, &clock);
+	write_chk_file(&clock, sizeof(clock));
+
+	// This is the actual page walk
+	determine_dirty_pages(write_mem_page_to_chk_file);
+
+	// Close the checkpoint file and release VCPUs
+	close_chk_file();
+	pthread_barrier_wait(&barrier);
+
+	// update configuration file
+	char chk_config_name[MAX_FNAME];
+	snprintf(chk_config_name, MAX_FNAME, "%s/chk_config.txt", chk_path);
+	FILE *f = fopen(chk_config_name, "w");
+	if (f == NULL) {
+		err(1, "fopen: unable to open file");
+	}
+
+	fprintf(f, "application path: %s\n", guest_path);
+	fprintf(f, "number of cores: %u\n", ncores);
+	fprintf(f, "memory size: 0x%zx\n", guest_size);
+	fprintf(f, "checkpoint number: %u\n", no_checkpoint);
+	fprintf(f, "entry point: 0x%zx\n", elf_entry);
+	if (full_checkpoint)
+		fprintf(f, "full checkpoint: 1");
+	else
+		fprintf(f, "full checkpoint: 0");
+
+	fclose(f);
+
+	if (verbose) {
+		gettimeofday(&end, NULL);
+		size_t msec = (end.tv_sec - begin.tv_sec) * 1000;
+		msec += (end.tv_usec - begin.tv_usec) / 1000;
+		fprintf(stderr,
+			"Create checkpoint %u in %zd ms\n",
+			no_checkpoint,
+			msec);
+	}
+
+	no_checkpoint++;
+}
+
+/**
+ * \brief Restore a checkpoint
+ *
+ * \param path The directory where the checkpoint is stored
+ *
+ * This function restores from a given checkpoint.
+ */
+int32_t
+restore_checkpoint(char *path)
+{
+	char           fname[MAX_FNAME];
+	size_t         location;
+	size_t         paddr = elf_entry;
+	int            ret;
+	struct timeval begin, end;
+	uint32_t       i;
+
+	if (verbose)
+		gettimeofday(&begin, NULL);
+
+	i = full_checkpoint ? no_checkpoint : 0;
+	for (; i <= no_checkpoint; i++) {
+		snprintf(fname, MAX_FNAME, "%s/chk%u_mem.dat", path, i);
+
+		// Open the checkpoint file for reading
+		FILE *f = fopen(fname, "r");
+		if (f == NULL)
+			return -1;
+		// Call the arch-specific restore routine
+		if (load_checkpoint(f, (i == no_checkpoint)) < 0)
+			return -1;
+
+		// Close the checkpoint file
+		fclose(f);
+	}
+
+	if (verbose) {
+		gettimeofday(&end, NULL);
+		size_t msec = (end.tv_sec - begin.tv_sec) * 1000;
+		msec += (end.tv_usec - begin.tv_usec) / 1000;
+		fprintf(stderr,
+			"Load checkpoint %u in %zd ms\n",
+			no_checkpoint,
+			msec);
+	}
+
+	return 0;
+}

--- a/uhyve-checkpoint.h
+++ b/uhyve-checkpoint.h
@@ -1,0 +1,46 @@
+#ifndef __UHYVE_CHECKPOINT_H__
+/*
+ * Copyright (c) 2018, RWTH Aachen University
+ * Author(s): Stefan Lankes <slankes@eonerc.rwth-aachen.de>
+ *            Simon Pickartz <spickartz@eonerc.rwth-aachen.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Simon Pickartz
+ * @file uhyve-checkpoint.h
+ * @brief Checkpointing-related functions
+ */
+
+#define __UHYVE_CHECKPOINT_H__
+
+#include <stdbool.h>
+
+int32_t load_checkpoint_config(const char *chkpt_config_path);
+void create_checkpoint(char *path, bool full_checkpoint);
+int32_t restore_checkpoint(char *path);
+
+void vcpu_thread_chk_handler(int signum);
+#endif /* __UHYVE_CHECKPOINT_H__ */

--- a/uhyve-json.c
+++ b/uhyve-json.c
@@ -1,0 +1,1239 @@
+/* vim: set et ts=3 sw=3 sts=3 ft=c:
+ *
+ * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+ * https://github.com/udp/json-parser
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "uhyve-json.h"
+
+#ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+#endif
+
+const struct _json_value json_value_none;
+
+#include <ctype.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef unsigned int json_uchar;
+
+static unsigned char
+hex_value(json_char c)
+{
+	if (isdigit(c))
+		return c - '0';
+
+	switch (c) {
+	case 'a':
+	case 'A':
+		return 0x0A;
+	case 'b':
+	case 'B':
+		return 0x0B;
+	case 'c':
+	case 'C':
+		return 0x0C;
+	case 'd':
+	case 'D':
+		return 0x0D;
+	case 'e':
+	case 'E':
+		return 0x0E;
+	case 'f':
+	case 'F':
+		return 0x0F;
+	default:
+		return 0xFF;
+	}
+}
+
+typedef struct {
+	unsigned long used_memory;
+
+	unsigned int  uint_max;
+	unsigned long ulong_max;
+
+	json_settings settings;
+	int           first_pass;
+
+	const json_char *ptr;
+	unsigned int     cur_line, cur_col;
+
+} json_state;
+
+static void *
+default_alloc(size_t size, int zero, void *user_data)
+{
+	return zero ? calloc(1, size) : malloc(size);
+}
+
+static void
+default_free(void *ptr, void *user_data)
+{
+	free(ptr);
+}
+
+static void *
+json_alloc(json_state *state, unsigned long size, int zero)
+{
+	if ((state->ulong_max - state->used_memory) < size)
+		return 0;
+
+	if (state->settings.max_memory &&
+	    (state->used_memory += size) > state->settings.max_memory) {
+		return 0;
+	}
+
+	return state->settings.mem_alloc(size, zero, state->settings.user_data);
+}
+
+static int
+new_value(json_state *state, json_value **top, json_value **root,
+	  json_value **alloc, json_type type)
+{
+	json_value *value;
+	int         values_size;
+
+	if (!state->first_pass) {
+		value = *top = *alloc;
+		*alloc       = (*alloc)->_reserved.next_alloc;
+
+		if (!*root)
+			*root = value;
+
+		switch (value->type) {
+		case json_array:
+
+			if (value->u.array.length == 0)
+				break;
+
+			if (!(value->u.array.values = (json_value **)json_alloc(
+				  state,
+				  value->u.array.length * sizeof(json_value *),
+				  0))) {
+				return 0;
+			}
+
+			value->u.array.length = 0;
+			break;
+
+		case json_object:
+
+			if (value->u.object.length == 0)
+				break;
+
+			values_size = sizeof(*value->u.object.values) *
+				      value->u.object.length;
+
+			if (!(value->u.object
+				  .values = (json_object_entry *)json_alloc(
+				  state,
+				  values_size +
+				      ((unsigned long)value->u.object.values),
+				  0))) {
+				return 0;
+			}
+
+			value->_reserved.object_mem =
+			    (*(char **)&value->u.object.values) + values_size;
+
+			value->u.object.length = 0;
+			break;
+
+		case json_string:
+
+			if (!(value->u.string.ptr = (json_char *)json_alloc(
+				  state,
+				  (value->u.string.length + 1) *
+				      sizeof(json_char),
+				  0))) {
+				return 0;
+			}
+
+			value->u.string.length = 0;
+			break;
+
+		default:
+			break;
+		};
+
+		return 1;
+	}
+
+	if (!(value = (json_value *)json_alloc(state,
+					       sizeof(json_value) +
+						   state->settings.value_extra,
+					       1))) {
+		return 0;
+	}
+
+	if (!*root)
+		*root = value;
+
+	value->type   = type;
+	value->parent = *top;
+
+#ifdef JSON_TRACK_SOURCE
+	value->line = state->cur_line;
+	value->col  = state->cur_col;
+#endif
+
+	if (*alloc)
+		(*alloc)->_reserved.next_alloc = value;
+
+	*alloc = *top = value;
+
+	return 1;
+}
+
+#define whitespace                                                             \
+	case '\n':                                                             \
+		++state.cur_line;                                              \
+		state.cur_col = 0;                                             \
+	case ' ':                                                              \
+	case '\t':                                                             \
+	case '\r'
+
+#define string_add(b)                                                          \
+	do {                                                                   \
+		if (!state.first_pass)                                         \
+			string[string_length] = b;                             \
+		++string_length;                                               \
+	} while (0);
+
+#define line_and_col state.cur_line, state.cur_col
+
+static const long flag_next = 1 << 0, flag_reproc = 1 << 1,
+		  flag_need_comma = 1 << 2, flag_seek_value = 1 << 3,
+		  flag_escaped = 1 << 4, flag_string = 1 << 5,
+		  flag_need_colon = 1 << 6, flag_done = 1 << 7,
+		  flag_num_negative = 1 << 8, flag_num_zero = 1 << 9,
+		  flag_num_e = 1 << 10, flag_num_e_got_sign = 1 << 11,
+		  flag_num_e_negative = 1 << 12, flag_line_comment = 1 << 13,
+		  flag_block_comment = 1 << 14;
+
+json_value *
+json_parse_ex(json_settings *settings, const json_char *json, size_t length,
+	      char *error_buf)
+{
+	json_char        error[json_error_max];
+	const json_char *end;
+	json_value *     top, *root, *alloc = 0;
+	json_state       state = {0};
+	long             flags;
+	long             num_digits = 0, num_e = 0;
+	json_int_t       num_fraction = 0;
+
+	/* Skip UTF-8 BOM
+	 */
+	if (length >= 3 && ((unsigned char)json[0]) == 0xEF &&
+	    ((unsigned char)json[1]) == 0xBB &&
+	    ((unsigned char)json[2]) == 0xBF) {
+		json += 3;
+		length -= 3;
+	}
+
+	error[0] = '\0';
+	end      = (json + length);
+
+	memcpy(&state.settings, settings, sizeof(json_settings));
+
+	if (!state.settings.mem_alloc)
+		state.settings.mem_alloc = default_alloc;
+
+	if (!state.settings.mem_free)
+		state.settings.mem_free = default_free;
+
+	memset(&state.uint_max, 0xFF, sizeof(state.uint_max));
+	memset(&state.ulong_max, 0xFF, sizeof(state.ulong_max));
+
+	state.uint_max -=
+	    8; /* limit of how much can be added before next check */
+	state.ulong_max -= 8;
+
+	for (state.first_pass = 1; state.first_pass >= 0; --state.first_pass) {
+		json_uchar    uchar;
+		unsigned char uc_b1, uc_b2, uc_b3, uc_b4;
+		json_char *   string        = 0;
+		unsigned int  string_length = 0;
+
+		top = root = 0;
+		flags      = flag_seek_value;
+
+		state.cur_line = 1;
+
+		for (state.ptr = json;; ++state.ptr) {
+			json_char b = (state.ptr == end ? 0 : *state.ptr);
+
+			if (flags & flag_string) {
+				if (!b) {
+					sprintf(
+					    error,
+					    "Unexpected EOF in string (at %d:%d)",
+					    line_and_col);
+					goto e_failed;
+				}
+
+				if (string_length > state.uint_max)
+					goto e_overflow;
+
+				if (flags & flag_escaped) {
+					flags &= ~flag_escaped;
+
+					switch (b) {
+					case 'b':
+						string_add('\b');
+						break;
+					case 'f':
+						string_add('\f');
+						break;
+					case 'n':
+						string_add('\n');
+						break;
+					case 'r':
+						string_add('\r');
+						break;
+					case 't':
+						string_add('\t');
+						break;
+					case 'u':
+
+						if (end - state.ptr <= 4 ||
+						    (uc_b1 = hex_value(
+							 *++state.ptr)) ==
+							0xFF ||
+						    (uc_b2 = hex_value(
+							 *++state.ptr)) ==
+							0xFF ||
+						    (uc_b3 = hex_value(
+							 *++state.ptr)) ==
+							0xFF ||
+						    (uc_b4 = hex_value(
+							 *++state.ptr)) ==
+							0xFF) {
+							sprintf(
+							    error,
+							    "Invalid character value `%c` (at %d:%d)",
+							    b,
+							    line_and_col);
+							goto e_failed;
+						}
+
+						uc_b1 = (uc_b1 << 4) | uc_b2;
+						uc_b2 = (uc_b3 << 4) | uc_b4;
+						uchar = (uc_b1 << 8) | uc_b2;
+
+						if ((uchar & 0xF800) ==
+						    0xD800) {
+							json_uchar uchar2;
+
+							if (end - state.ptr <=
+								6 ||
+							    (*++state.ptr) !=
+								'\\' ||
+							    (*++state.ptr) !=
+								'u' ||
+							    (uc_b1 = hex_value(
+								 *++state
+									.ptr)) ==
+								0xFF ||
+							    (uc_b2 = hex_value(
+								 *++state
+									.ptr)) ==
+								0xFF ||
+							    (uc_b3 = hex_value(
+								 *++state
+									.ptr)) ==
+								0xFF ||
+							    (uc_b4 = hex_value(
+								 *++state
+									.ptr)) ==
+								0xFF) {
+								sprintf(
+								    error,
+								    "Invalid character value `%c` (at %d:%d)",
+								    b,
+								    line_and_col);
+								goto e_failed;
+							}
+
+							uc_b1 = (uc_b1 << 4) |
+								uc_b2;
+							uc_b2 = (uc_b3 << 4) |
+								uc_b4;
+							uchar2 = (uc_b1 << 8) |
+								 uc_b2;
+
+							uchar =
+							    0x010000 |
+							    ((uchar & 0x3FF)
+							     << 10) |
+							    (uchar2 & 0x3FF);
+						}
+
+						if (sizeof(json_char) >=
+							sizeof(json_uchar) ||
+						    (uchar <= 0x7F)) {
+							string_add(
+							    (json_char)uchar);
+							break;
+						}
+
+						if (uchar <= 0x7FF) {
+							if (state.first_pass)
+								string_length +=
+								    2;
+							else {
+								string
+								    [string_length++] =
+									0xC0 |
+									(uchar >>
+									 6);
+								string
+								    [string_length++] =
+									0x80 |
+									(uchar &
+									 0x3F);
+							}
+
+							break;
+						}
+
+						if (uchar <= 0xFFFF) {
+							if (state.first_pass)
+								string_length +=
+								    3;
+							else {
+								string
+								    [string_length++] =
+									0xE0 |
+									(uchar >>
+									 12);
+								string
+								    [string_length++] =
+									0x80 |
+									((uchar >>
+									  6) &
+									 0x3F);
+								string
+								    [string_length++] =
+									0x80 |
+									(uchar &
+									 0x3F);
+							}
+
+							break;
+						}
+
+						if (state.first_pass)
+							string_length += 4;
+						else {
+							string
+							    [string_length++] =
+								0xF0 |
+								(uchar >> 18);
+							string
+							    [string_length++] =
+								0x80 |
+								((uchar >> 12) &
+								 0x3F);
+							string
+							    [string_length++] =
+								0x80 |
+								((uchar >> 6) &
+								 0x3F);
+							string
+							    [string_length++] =
+								0x80 |
+								(uchar & 0x3F);
+						}
+
+						break;
+
+					default:
+						string_add(b);
+					};
+
+					continue;
+				}
+
+				if (b == '\\') {
+					flags |= flag_escaped;
+					continue;
+				}
+
+				if (b == '"') {
+					if (!state.first_pass)
+						string[string_length] = 0;
+
+					flags &= ~flag_string;
+					string = 0;
+
+					switch (top->type) {
+					case json_string:
+
+						top->u.string.length =
+						    string_length;
+						flags |= flag_next;
+
+						break;
+
+					case json_object:
+
+						if (state.first_pass)
+							(*(json_char **)&top->u
+							      .object.values) +=
+							    string_length + 1;
+						else {
+							top->u.object
+							    .values[top->u
+									.object
+									.length]
+							    .name =
+							    (json_char *)
+								top->_reserved
+								    .object_mem;
+
+							top->u.object
+							    .values[top->u
+									.object
+									.length]
+							    .name_length =
+							    string_length;
+
+							(*(json_char **)&top
+							      ->_reserved
+							      .object_mem) +=
+							    string_length + 1;
+						}
+
+						flags |= flag_seek_value |
+							 flag_need_colon;
+						continue;
+
+					default:
+						break;
+					};
+				} else {
+					string_add(b);
+					continue;
+				}
+			}
+
+			if (state.settings.settings & json_enable_comments) {
+				if (flags &
+				    (flag_line_comment | flag_block_comment)) {
+					if (flags & flag_line_comment) {
+						if (b == '\r' || b == '\n' ||
+						    !b) {
+							flags &=
+							    ~flag_line_comment;
+							--state
+							      .ptr; /* so null
+								       can be
+								       reproc'd
+								       */
+						}
+
+						continue;
+					}
+
+					if (flags & flag_block_comment) {
+						if (!b) {
+							sprintf(
+							    error,
+							    "%d:%d: Unexpected EOF in block comment",
+							    line_and_col);
+							goto e_failed;
+						}
+
+						if (b == '*' &&
+						    state.ptr < (end - 1) &&
+						    state.ptr[1] == '/') {
+							flags &=
+							    ~flag_block_comment;
+							++state
+							      .ptr; /* skip
+								       closing
+								       sequence
+								       */
+						}
+
+						continue;
+					}
+				} else if (b == '/') {
+					if (!(flags &
+					      (flag_seek_value | flag_done)) &&
+					    top->type != json_object) {
+						sprintf(
+						    error,
+						    "%d:%d: Comment not allowed here",
+						    line_and_col);
+						goto e_failed;
+					}
+
+					if (++state.ptr == end) {
+						sprintf(error,
+							"%d:%d: EOF unexpected",
+							line_and_col);
+						goto e_failed;
+					}
+
+					switch (b = *state.ptr) {
+					case '/':
+						flags |= flag_line_comment;
+						continue;
+
+					case '*':
+						flags |= flag_block_comment;
+						continue;
+
+					default:
+						sprintf(
+						    error,
+						    "%d:%d: Unexpected `%c` in comment opening sequence",
+						    line_and_col,
+						    b);
+						goto e_failed;
+					};
+				}
+			}
+
+			if (flags & flag_done) {
+				if (!b)
+					break;
+
+				switch (b) {
+				whitespace:
+					continue;
+
+				default:
+
+					sprintf(error,
+						"%d:%d: Trailing garbage: `%c`",
+						state.cur_line,
+						state.cur_col,
+						b);
+
+					goto e_failed;
+				};
+			}
+
+			if (flags & flag_seek_value) {
+				switch (b) {
+				whitespace:
+					continue;
+
+				case ']':
+
+					if (top && top->type == json_array)
+						flags = (flags &
+							 ~(flag_need_comma |
+							   flag_seek_value)) |
+							flag_next;
+					else {
+						sprintf(error,
+							"%d:%d: Unexpected ]",
+							line_and_col);
+						goto e_failed;
+					}
+
+					break;
+
+				default:
+
+					if (flags & flag_need_comma) {
+						if (b == ',') {
+							flags &=
+							    ~flag_need_comma;
+							continue;
+						} else {
+							sprintf(
+							    error,
+							    "%d:%d: Expected , before %c",
+							    state.cur_line,
+							    state.cur_col,
+							    b);
+
+							goto e_failed;
+						}
+					}
+
+					if (flags & flag_need_colon) {
+						if (b == ':') {
+							flags &=
+							    ~flag_need_colon;
+							continue;
+						} else {
+							sprintf(
+							    error,
+							    "%d:%d: Expected : before %c",
+							    state.cur_line,
+							    state.cur_col,
+							    b);
+
+							goto e_failed;
+						}
+					}
+
+					flags &= ~flag_seek_value;
+
+					switch (b) {
+					case '{':
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_object))
+							goto e_alloc_failure;
+
+						continue;
+
+					case '[':
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_array))
+							goto e_alloc_failure;
+
+						flags |= flag_seek_value;
+						continue;
+
+					case '"':
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_string))
+							goto e_alloc_failure;
+
+						flags |= flag_string;
+
+						string = top->u.string.ptr;
+						string_length = 0;
+
+						continue;
+
+					case 't':
+
+						if ((end - state.ptr) < 3 ||
+						    *(++state.ptr) != 'r' ||
+						    *(++state.ptr) != 'u' ||
+						    *(++state.ptr) != 'e') {
+							goto e_unknown_value;
+						}
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_boolean))
+							goto e_alloc_failure;
+
+						top->u.boolean = 1;
+
+						flags |= flag_next;
+						break;
+
+					case 'f':
+
+						if ((end - state.ptr) < 4 ||
+						    *(++state.ptr) != 'a' ||
+						    *(++state.ptr) != 'l' ||
+						    *(++state.ptr) != 's' ||
+						    *(++state.ptr) != 'e') {
+							goto e_unknown_value;
+						}
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_boolean))
+							goto e_alloc_failure;
+
+						flags |= flag_next;
+						break;
+
+					case 'n':
+
+						if ((end - state.ptr) < 3 ||
+						    *(++state.ptr) != 'u' ||
+						    *(++state.ptr) != 'l' ||
+						    *(++state.ptr) != 'l') {
+							goto e_unknown_value;
+						}
+
+						if (!new_value(&state,
+							       &top,
+							       &root,
+							       &alloc,
+							       json_null))
+							goto e_alloc_failure;
+
+						flags |= flag_next;
+						break;
+
+					default:
+
+						if (isdigit(b) || b == '-') {
+							if (!new_value(
+								&state,
+								&top,
+								&root,
+								&alloc,
+								json_integer))
+								goto e_alloc_failure;
+
+							if (!state.first_pass) {
+								while (
+								    isdigit(
+									b) ||
+								    b == '+' ||
+								    b == '-' ||
+								    b == 'e' ||
+								    b == 'E' ||
+								    b == '.') {
+									if ((++state
+										   .ptr) ==
+									    end) {
+										b = 0;
+										break;
+									}
+
+									b = *state
+										 .ptr;
+								}
+
+								flags |=
+								    flag_next |
+								    flag_reproc;
+								break;
+							}
+
+							flags &= ~(
+							    flag_num_negative |
+							    flag_num_e |
+							    flag_num_e_got_sign |
+							    flag_num_e_negative |
+							    flag_num_zero);
+
+							num_digits   = 0;
+							num_fraction = 0;
+							num_e        = 0;
+
+							if (b != '-') {
+								flags |=
+								    flag_reproc;
+								break;
+							}
+
+							flags |=
+							    flag_num_negative;
+							continue;
+						} else {
+							sprintf(
+							    error,
+							    "%d:%d: Unexpected %c when seeking value",
+							    line_and_col,
+							    b);
+							goto e_failed;
+						}
+					};
+				};
+			} else {
+				switch (top->type) {
+				case json_object:
+
+					switch (b) {
+					whitespace:
+						continue;
+
+					case '"':
+
+						if (flags & flag_need_comma) {
+							sprintf(
+							    error,
+							    "%d:%d: Expected , before \"",
+							    line_and_col);
+							goto e_failed;
+						}
+
+						flags |= flag_string;
+
+						string =
+						    (json_char *)top->_reserved
+							.object_mem;
+						string_length = 0;
+
+						break;
+
+					case '}':
+
+						flags =
+						    (flags & ~flag_need_comma) |
+						    flag_next;
+						break;
+
+					case ',':
+
+						if (flags & flag_need_comma) {
+							flags &=
+							    ~flag_need_comma;
+							break;
+						}
+
+					default:
+						sprintf(
+						    error,
+						    "%d:%d: Unexpected `%c` in object",
+						    line_and_col,
+						    b);
+						goto e_failed;
+					};
+
+					break;
+
+				case json_integer:
+				case json_double:
+
+					if (isdigit(b)) {
+						++num_digits;
+
+						if (top->type == json_integer ||
+						    flags & flag_num_e) {
+							if (!(flags &
+							      flag_num_e)) {
+								if (flags &
+								    flag_num_zero) {
+									sprintf(
+									    error,
+									    "%d:%d: Unexpected `0` before `%c`",
+									    line_and_col,
+									    b);
+									goto e_failed;
+								}
+
+								if (num_digits ==
+									1 &&
+								    b == '0')
+									flags |=
+									    flag_num_zero;
+							} else {
+								flags |=
+								    flag_num_e_got_sign;
+								num_e =
+								    (num_e *
+								     10) +
+								    (b - '0');
+								continue;
+							}
+
+							top->u.integer =
+							    (top->u.integer *
+							     10) +
+							    (b - '0');
+							continue;
+						}
+
+						num_fraction =
+						    (num_fraction * 10) +
+						    (b - '0');
+						continue;
+					}
+
+					if (b == '+' || b == '-') {
+						if ((flags & flag_num_e) &&
+						    !(flags &
+						      flag_num_e_got_sign)) {
+							flags |=
+							    flag_num_e_got_sign;
+
+							if (b == '-')
+								flags |=
+								    flag_num_e_negative;
+
+							continue;
+						}
+					} else if (b == '.' &&
+						   top->type == json_integer) {
+						if (!num_digits) {
+							sprintf(
+							    error,
+							    "%d:%d: Expected digit before `.`",
+							    line_and_col);
+							goto e_failed;
+						}
+
+						top->type = json_double;
+						top->u.dbl =
+						    (double)top->u.integer;
+
+						num_digits = 0;
+						continue;
+					}
+
+					if (!(flags & flag_num_e)) {
+						if (top->type == json_double) {
+							if (!num_digits) {
+								sprintf(
+								    error,
+								    "%d:%d: Expected digit after `.`",
+								    line_and_col);
+								goto e_failed;
+							}
+
+							top->u.dbl +=
+							    ((double)
+								 num_fraction) /
+							    (pow(
+								10.0,
+								(double)
+								    num_digits));
+						}
+
+						if (b == 'e' || b == 'E') {
+							flags |= flag_num_e;
+
+							if (top->type ==
+							    json_integer) {
+								top->type =
+								    json_double;
+								top->u.dbl =
+								    (double)top
+									->u
+									.integer;
+							}
+
+							num_digits = 0;
+							flags &= ~flag_num_zero;
+
+							continue;
+						}
+					} else {
+						if (!num_digits) {
+							sprintf(
+							    error,
+							    "%d:%d: Expected digit after `e`",
+							    line_and_col);
+							goto e_failed;
+						}
+
+						top->u.dbl *= pow(
+						    10.0,
+						    (double)(flags & flag_num_e_negative
+								 ? -num_e
+								 : num_e));
+					}
+
+					if (flags & flag_num_negative) {
+						if (top->type == json_integer)
+							top->u.integer =
+							    -top->u.integer;
+						else
+							top->u.dbl =
+							    -top->u.dbl;
+					}
+
+					flags |= flag_next | flag_reproc;
+					break;
+
+				default:
+					break;
+				};
+			}
+
+			if (flags & flag_reproc) {
+				flags &= ~flag_reproc;
+				--state.ptr;
+			}
+
+			if (flags & flag_next) {
+				flags = (flags & ~flag_next) | flag_need_comma;
+
+				if (!top->parent) {
+					/* root value done */
+
+					flags |= flag_done;
+					continue;
+				}
+
+				if (top->parent->type == json_array)
+					flags |= flag_seek_value;
+
+				if (!state.first_pass) {
+					json_value *parent = top->parent;
+
+					switch (parent->type) {
+					case json_object:
+
+						parent->u.object
+						    .values[parent->u.object
+								.length]
+						    .value = top;
+
+						break;
+
+					case json_array:
+
+						parent->u.array
+						    .values[parent->u.array
+								.length] = top;
+
+						break;
+
+					default:
+						break;
+					};
+				}
+
+				if ((++top->parent->u.array.length) >
+				    state.uint_max)
+					goto e_overflow;
+
+				top = top->parent;
+
+				continue;
+			}
+		}
+
+		alloc = root;
+	}
+
+	return root;
+
+e_unknown_value:
+
+	sprintf(error, "%d:%d: Unknown value", line_and_col);
+	goto e_failed;
+
+e_alloc_failure:
+
+	strcpy(error, "Memory allocation failure");
+	goto e_failed;
+
+e_overflow:
+
+	sprintf(error, "%d:%d: Too long (caught overflow)", line_and_col);
+	goto e_failed;
+
+e_failed:
+
+	if (error_buf) {
+		if (*error)
+			strcpy(error_buf, error);
+		else
+			strcpy(error_buf, "Unknown error");
+	}
+
+	if (state.first_pass)
+		alloc = root;
+
+	while (alloc) {
+		top = alloc->_reserved.next_alloc;
+		state.settings.mem_free(alloc, state.settings.user_data);
+		alloc = top;
+	}
+
+	if (!state.first_pass)
+		json_value_free_ex(&state.settings, root);
+
+	return 0;
+}
+
+json_value *
+json_parse(const json_char *json, size_t length)
+{
+	json_settings settings = {0};
+	return json_parse_ex(&settings, json, length, 0);
+}
+
+void
+json_value_free_ex(json_settings *settings, json_value *value)
+{
+	json_value *cur_value;
+
+	if (!value)
+		return;
+
+	value->parent = 0;
+
+	while (value) {
+		switch (value->type) {
+		case json_array:
+
+			if (!value->u.array.length) {
+				settings->mem_free(value->u.array.values,
+						   settings->user_data);
+				break;
+			}
+
+			value = value->u.array.values[--value->u.array.length];
+			continue;
+
+		case json_object:
+
+			if (!value->u.object.length) {
+				settings->mem_free(value->u.object.values,
+						   settings->user_data);
+				break;
+			}
+
+			value = value->u.object.values[--value->u.object.length]
+				    .value;
+			continue;
+
+		case json_string:
+
+			settings->mem_free(value->u.string.ptr,
+					   settings->user_data);
+			break;
+
+		default:
+			break;
+		};
+
+		cur_value = value;
+		value     = value->parent;
+		settings->mem_free(cur_value, settings->user_data);
+	}
+}
+
+void
+json_value_free(json_value *value)
+{
+	json_settings settings = {0};
+	settings.mem_free      = default_free;
+	json_value_free_ex(&settings, value);
+}

--- a/uhyve-json.h
+++ b/uhyve-json.h
@@ -1,0 +1,264 @@
+/* vim: set et ts=3 sw=3 sts=3 ft=c:
+ *
+ * Copyright (C) 2012, 2013, 2014 James McLaughlin et al.  All rights reserved.
+ * https://github.com/udp/json-parser
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _JSON_H
+#define _JSON_H
+
+#ifndef json_char
+#define json_char char
+#endif
+
+#ifndef json_int_t
+#ifndef _MSC_VER
+#include <inttypes.h>
+#define json_int_t int64_t
+#else
+#define json_int_t __int64
+#endif
+#endif
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+
+#include <string.h>
+
+extern "C" {
+
+#endif
+
+typedef struct {
+	unsigned long max_memory;
+	int           settings;
+
+	/* Custom allocator support (leave null to use malloc/free)
+	 */
+
+	void *(*mem_alloc)(size_t, int zero, void *user_data);
+	void (*mem_free)(void *, void *user_data);
+
+	void *user_data; /* will be passed to mem_alloc and mem_free */
+
+	size_t value_extra; /* how much extra space to allocate for values? */
+
+} json_settings;
+
+#define json_enable_comments 0x01
+
+typedef enum {
+	json_none,
+	json_object,
+	json_array,
+	json_integer,
+	json_double,
+	json_string,
+	json_boolean,
+	json_null
+
+} json_type;
+
+extern const struct _json_value json_value_none;
+
+typedef struct _json_object_entry {
+	json_char *  name;
+	unsigned int name_length;
+
+	struct _json_value *value;
+
+} json_object_entry;
+
+typedef struct _json_value {
+	struct _json_value *parent;
+
+	json_type type;
+
+	union {
+		int        boolean;
+		json_int_t integer;
+		double     dbl;
+
+		struct {
+			unsigned int length;
+			json_char *  ptr; /* null terminated */
+
+		} string;
+
+		struct {
+			unsigned int length;
+
+			json_object_entry *values;
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+			decltype(values)
+			begin() const
+			{
+				return values;
+			}
+			decltype(values)
+			end() const
+			{
+				return values + length;
+			}
+#endif
+
+		} object;
+
+		struct {
+			unsigned int         length;
+			struct _json_value **values;
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+			decltype(values)
+			begin() const
+			{
+				return values;
+			}
+			decltype(values)
+			end() const
+			{
+				return values + length;
+			}
+#endif
+
+		} array;
+
+	} u;
+
+	union {
+		struct _json_value *next_alloc;
+		void *              object_mem;
+
+	} _reserved;
+
+#ifdef JSON_TRACK_SOURCE
+
+	/* Location of the value in the source JSON
+	 */
+	unsigned int line, col;
+
+#endif
+
+/* Some C++ operator sugar */
+
+#ifdef __cplusplus
+
+      public:
+	inline _json_value() { memset(this, 0, sizeof(_json_value)); }
+
+	inline const struct _json_value &operator[](int index) const
+	{
+		if (type != json_array || index < 0 ||
+		    ((unsigned int)index) >= u.array.length) {
+			return json_value_none;
+		}
+
+		return *u.array.values[index];
+	}
+
+	inline const struct _json_value &operator[](const char *index) const
+	{
+		if (type != json_object)
+			return json_value_none;
+
+		for (unsigned int i = 0; i < u.object.length; ++i)
+			if (!strcmp(u.object.values[i].name, index))
+				return *u.object.values[i].value;
+
+		return json_value_none;
+	}
+
+	inline operator const char *() const
+	{
+		switch (type) {
+		case json_string:
+			return u.string.ptr;
+
+		default:
+			return "";
+		};
+	}
+
+	inline operator json_int_t() const
+	{
+		switch (type) {
+		case json_integer:
+			return u.integer;
+
+		case json_double:
+			return (json_int_t)u.dbl;
+
+		default:
+			return 0;
+		};
+	}
+
+	inline operator bool() const
+	{
+		if (type != json_boolean)
+			return false;
+
+		return u.boolean != 0;
+	}
+
+	inline operator double() const
+	{
+		switch (type) {
+		case json_integer:
+			return (double)u.integer;
+
+		case json_double:
+			return u.dbl;
+
+		default:
+			return 0;
+		};
+	}
+
+#endif
+
+} json_value;
+
+json_value *json_parse(const json_char *json, size_t length);
+
+#define json_error_max 128
+json_value *json_parse_ex(json_settings *settings, const json_char *json,
+			  size_t length, char *error);
+
+void json_value_free(json_value *);
+
+/* Not usually necessary, unless you used a custom mem_alloc and now want to
+ * use a custom mem_free.
+ */
+void json_value_free_ex(json_settings *settings, json_value *);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif

--- a/uhyve-migration.c
+++ b/uhyve-migration.c
@@ -102,12 +102,33 @@ define_migration_param_getter(type)
 define_migration_param_getter(mode)
 
 /**
+ * \brief Enables/disables ODP
+ */
+void
+set_migration_use_odp(const bool use_odp)
+{
+	mig_params.use_odp = use_odp;
+}
+
+
+/**
+ * \brief Enables/disables prefetching for ODP
+ */
+void
+set_migration_prefetch(const bool prefetch)
+{
+	mig_params.prefetch = prefetch;
+}
+
+
+/**
  * \brief prints the migration parameters
  */
 void
 print_migration_params(void)
 {
 	printf("========== MIGRATION PARAMETERS ==========\n");
+	printf("   DEST     : %s\n", inet_ntoa(mig_server.sin_addr));
 	printf("   MODE     : %s\n", get_migration_mode_str(mig_params.mode));
 	printf("   TYPE     : %s\n", get_migration_type_str(mig_params.type));
 	printf("   USE ODP  : %u\n", mig_params.use_odp);

--- a/uhyve-migration.h
+++ b/uhyve-migration.h
@@ -99,6 +99,10 @@ typedef struct _migration_metadata {
 mig_params_t mig_params;
 
 void set_migration_params(const char *migration_param_filename);
+void set_migration_mode(const char *);
+void set_migration_type(const char *);
+void set_migration_use_odp(const bool);
+void set_migration_prefetch(const bool);
 
 mig_type_t get_migration_type(void);
 

--- a/uhyve-monitor.c
+++ b/uhyve-monitor.c
@@ -1,0 +1,524 @@
+/*
+ * Copyright (c) 2018, Simon Pickartz, RWTH Aachen University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <event.h>
+#include <event2/listener.h>
+#include <event2/thread.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "uhyve-checkpoint.h"
+#include "uhyve-json.h"
+#include "uhyve-migration.h"
+#include "uhyve-monitor.h"
+#include "uhyve.h"
+
+#define MIN(a, b) (a) < (b) ? (a) : (b)
+#define UHYVE_SOCK_PATH "/tmp/uhyve.sock"
+#define JSON_TASK_STR "task"
+
+static uint32_t uhyve_monitor_handle_start_app(json_value *json_task);
+static uint32_t uhyve_monitor_handle_create_checkpoint(json_value *json_task);
+static uint32_t uhyve_monitor_handle_load_checkpoint(json_value *json_task);
+static uint32_t uhyve_monitor_handle_migrate(json_value *json_task);
+
+extern uint8_t *  guest_mem;
+extern uint32_t   ncores;
+extern sem_t      monitor_sem;
+extern pthread_t *vcpu_threads;
+
+typedef struct uhyve_monitor_sock {
+	struct evconnlistener *listener;
+	int                    sock;
+	struct sockaddr_un     unix_sock_addr;
+	int                    len;
+} uhyve_monitor_sock_t;
+
+typedef struct uhyve_monitor_event {
+	struct event       accept_ev;
+	struct event_base *evbase;
+} uhyve_monitor_event_t;
+
+static uhyve_monitor_sock_t  uhyve_monitor_sock;
+static uhyve_monitor_event_t uhyve_monitor_event;
+static pthread_t             uhyve_monitor_thread;
+static bool                  uhyve_monitor_initialized = 0;
+static bool                  uhyve_monitor_exit        = 0;
+
+// these globals are required for the checkpoint handler
+// TODO: this is a workaround (see comment in uhyve_monitor_init()
+static bool  full_checkpoint = false;
+static char *chk_path        = NULL;
+static sem_t chk_sem;
+
+typedef uint32_t (*task_handler_t)(json_value *json_task);
+typedef struct _task_to_handler_elem {
+	const char *   name;
+	task_handler_t handler;
+} task_to_handler_elem_t;
+
+static const task_to_handler_elem_t task_to_handler[] = {
+    {"start app", uhyve_monitor_handle_start_app},
+    {"create checkpoint", uhyve_monitor_handle_create_checkpoint},
+    {"load checkpoint", uhyve_monitor_handle_load_checkpoint},
+    {"migrate", uhyve_monitor_handle_migrate},
+};
+
+static const int task_to_handler_len =
+    sizeof(task_to_handler) / sizeof(task_to_handler[0]);
+
+static json_value *
+find_json_field(const char *field_name, json_value *json_task)
+{
+	uint32_t i = 0;
+	for (i = 0; i < json_task->u.object.length; ++i) {
+		const json_char *entry_name =
+		    json_task->u.object.values[i].name;
+		const size_t entry_name_length =
+		    json_task->u.object.values[i].name_length;
+		size_t max_n = MIN(entry_name_length, strlen(field_name));
+
+		if (strncmp(entry_name, field_name, max_n) == 0)
+			return json_task->u.object.values[i].value;
+	}
+
+	return NULL;
+}
+
+static void
+uhyve_monitor_on_conn_event(struct bufferevent *bev, short events,
+			    void *user_data)
+{
+	if (events & BEV_EVENT_EOF) {
+		// free the event buffer
+		bufferevent_free(bev);
+	} else if (events & BEV_EVENT_ERROR) {
+		perror("Got an error on the connection");
+	}
+}
+
+static void
+uhyve_monitor_checkpoint_handler(int signum)
+{
+	create_checkpoint(chk_path, full_checkpoint);
+	sem_post(&chk_sem);
+}
+
+/**
+ * \brief The uyve task handler
+ *
+ * \param task A json string encoding the task
+ * \param length length of the task string
+ *
+ * This is the task handler that processes the json request to:
+ * - migrate
+ * - create/restore checkpoints
+ * - start an application
+ * - modify the guest configuration
+ */
+static uint32_t
+uhyve_monitor_task_handler(void *task, size_t length)
+{
+	uint32_t status_code = 0;
+
+	// parse the json task
+	json_value *json_task = json_parse((const json_char *)task, length);
+
+	// find task field
+	json_value *task_json = NULL;
+	if ((task_json = find_json_field(JSON_TASK_STR, json_task)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Json string does not contain a '%s' field. Abort!\n",
+		    JSON_TASK_STR);
+		return 400;
+	}
+
+	// determine task
+	const json_char *task_name        = task_json->u.string.ptr;
+	const size_t     task_name_length = task_json->u.string.length;
+
+	uint32_t i = 0;
+	for (i = 0; i < task_to_handler_len; ++i) {
+		const size_t max_n =
+		    MIN(task_name_length, strlen(task_to_handler[i].name));
+		if (strncmp(task_name, task_to_handler[i].name, max_n) == 0) {
+			status_code = task_to_handler[i].handler(json_task);
+			break;
+		}
+	}
+
+	// task not found -> return 'Not Implemented'
+	if (i == task_to_handler_len) {
+		fprintf(stderr,
+			"[WARNING] Task '%s' not implemented.\n",
+			task_name);
+		status_code = 501;
+	}
+
+	return status_code;
+}
+
+/**
+ * \brief Task handler for: application start
+ */
+static uint32_t
+uhyve_monitor_handle_start_app(json_value *json_task)
+{
+	// TODO: check if an application is already running
+
+	// find path field
+	json_value *path_json = NULL;
+	if ((path_json = find_json_field("path", json_task)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Start task is missing the 'path' field. Abort!\n");
+		return 400;
+	}
+
+	// initialize the hypervisor
+	init_kvm_arch();
+
+	// load the given application
+	char *path = path_json->u.string.ptr;
+	if (load_kernel(guest_mem, path) != 0)
+		exit(EXIT_FAILURE);
+	sem_post(&monitor_sem);
+
+	return 200;
+}
+
+/**
+ * \brief Task handler for: checkpoint
+ */
+static uint32_t
+uhyve_monitor_handle_create_checkpoint(json_value *json_task)
+{
+	// find params field
+	json_value *params_json = NULL;
+	if ((params_json = find_json_field("params", json_task)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Checkpoint task is missing the 'params' field. Abort!\n");
+		return 400;
+	}
+
+	// determine checkpoint parameters
+	//
+	json_value *chk_param_json = NULL;
+	// path
+	if ((chk_param_json = find_json_field("path", params_json)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Checkpoint task is missing the 'path' parameter. Abort!\n");
+		return 400;
+	} else {
+		chk_path = chk_param_json->u.string.ptr;
+	}
+	// full-checkpoint
+	if ((chk_param_json =
+		 find_json_field("full-checkpoint", params_json)) != NULL) {
+		full_checkpoint = chk_param_json->u.boolean;
+	}
+
+	// create the checkpoint
+	// TODO: this is a workaround (see comment in uhyve_monitor_init()
+	pthread_kill(vcpu_threads[0], SIGCHKP);
+	sem_wait(&chk_sem);
+
+	return 200;
+}
+
+/**
+ * \brief Task handler for: restore
+ */
+static uint32_t
+uhyve_monitor_handle_load_checkpoint(json_value *json_task)
+{
+	// find path field
+	json_value *path_json = NULL;
+	if ((path_json = find_json_field("path", json_task)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Checkpoint task is missing the 'path' field. Abort!\n");
+		return 400;
+	}
+
+	// load the checkpoint configuration
+	char *chk_path = path_json->u.string.ptr;
+	if (load_checkpoint_config(chk_path) < 0) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Could not load the chk_config.txt within '%s'. Abort!\n",
+		    chk_path);
+		return 400;
+	}
+
+	// allocate VCPU data structures
+	if (uhyve_allocate_vcpus(ncores) < 0) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Could not allocate VCPU data structures. Abort!\n");
+		return 500;
+	}
+
+	// initialize the hypervisor and restore the checkpoint image
+	init_kvm_arch();
+	restore_checkpoint(chk_path);
+	sem_post(&monitor_sem);
+
+	return 200;
+}
+
+/**
+ * \brief Task handler for: migration
+ */
+static uint32_t
+uhyve_monitor_handle_migrate(json_value *json_task)
+{
+	// find params field
+	json_value *params_json = NULL;
+	if ((params_json = find_json_field("params", json_task)) == NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Migrate task is missing the 'params' field. Abort!\n");
+		return 400;
+	}
+
+	// determine migratin parameters
+	//
+	// destination
+	json_value *mig_param_json = NULL;
+	if ((mig_param_json = find_json_field("destination", params_json)) ==
+	    NULL) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Migrate task is missing the 'destination' parameter. Abort!\n");
+		return 400;
+	} else {
+		set_migration_target(mig_param_json->u.string.ptr,
+				     MIGRATION_PORT);
+	}
+	// mode
+	if ((mig_param_json = find_json_field("mode", params_json)) != NULL) {
+		set_migration_mode(mig_param_json->u.string.ptr);
+	}
+	// type
+	if ((mig_param_json = find_json_field("type", params_json)) != NULL) {
+		set_migration_type(mig_param_json->u.string.ptr);
+	}
+	// odp
+	if ((mig_param_json = find_json_field("use-odp", params_json)) !=
+	    NULL) {
+		set_migration_use_odp(mig_param_json->u.boolean);
+	}
+	// prefetch
+	if ((mig_param_json = find_json_field("prefetch", params_json)) !=
+	    NULL) {
+		set_migration_prefetch(mig_param_json->u.boolean);
+	}
+
+	// connect to the migraiton server and call the handler (arch specific)
+	if (connect_to_server() < 0) {
+		fprintf(
+		    stderr,
+		    "[ERROR] Could not connect to the destination. Abort!\n");
+		return 502;
+	} else {
+		migration_handler();
+		uhyve_monitor_exit = true;
+		return 200;
+	}
+}
+
+/**
+ * \brief Get a task string out of the event buffer
+ */
+static void
+uhyve_monitor_receive_task(struct bufferevent *bev, void *user_data)
+{
+	// get the message out of the buffer
+	struct evbuffer *input         = bufferevent_get_input(bev);
+	size_t           bytes_to_read = evbuffer_get_length(input);
+	void *           msg           = malloc(bytes_to_read);
+	bufferevent_read(bev, msg, bytes_to_read);
+
+	// pass the message to the task handler
+	uint32_t status_code = uhyve_monitor_task_handler(msg, bytes_to_read);
+	free(msg);
+
+	// return the status code to the requesting entity
+	char status_code_str[4];
+	sprintf(status_code_str, "%u", status_code);
+	if (bufferevent_write(bev, status_code_str, 4) < 0) {
+		err(1, "[ERROR] Could write to the event buffer.");
+	}
+
+	// shall we exit the monitor?
+	if (uhyve_monitor_exit)
+		exit(EXIT_SUCCESS);
+}
+
+/**
+ * \brief This callback is invoked once a client connects to the monitor
+ */
+static void
+uhyve_monitor_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
+			struct sockaddr *sa, int socklen, void *user_data)
+{
+	// create a new buffer event socket and register callbacks
+	struct bufferevent *bev;
+	if ((bev = bufferevent_socket_new(
+		 uhyve_monitor_event.evbase, fd, BEV_OPT_CLOSE_ON_FREE)) < 0) {
+		err(1, "[ERROR] Could not construct bufferevent.");
+	}
+	bufferevent_setcb(bev,
+			  uhyve_monitor_receive_task,
+			  NULL,
+			  uhyve_monitor_on_conn_event,
+			  NULL);
+	bufferevent_enable(bev, EV_READ | EV_WRITE);
+}
+
+/**
+ * \brief Initializes the event socket
+ */
+static void
+uhyve_monitor_init_evconnlistener(void)
+{
+	// cleanup old socket
+	unlink(UHYVE_SOCK_PATH);
+
+	memset(&uhyve_monitor_sock.unix_sock_addr,
+	       0,
+	       sizeof(&uhyve_monitor_sock.unix_sock_addr));
+	uhyve_monitor_sock.unix_sock_addr.sun_family = AF_UNIX;
+	strncpy(uhyve_monitor_sock.unix_sock_addr.sun_path,
+		UHYVE_SOCK_PATH,
+		sizeof(uhyve_monitor_sock.unix_sock_addr.sun_path) - 1);
+	uhyve_monitor_sock.listener = evconnlistener_new_bind(
+	    uhyve_monitor_event.evbase,
+	    uhyve_monitor_on_accept,
+	    NULL,
+	    LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE,
+	    -1,
+	    (struct sockaddr *)&uhyve_monitor_sock.unix_sock_addr,
+	    sizeof(uhyve_monitor_sock.unix_sock_addr));
+
+	if (uhyve_monitor_sock.listener == NULL) {
+		err(1, "[ERROR] Could not create the event listener.");
+	}
+}
+
+/*
+ * \brief The uhyve monitor event loop
+ */
+void *
+uhyve_monitor_event_loop(void *args)
+{
+	if (event_base_dispatch(uhyve_monitor_event.evbase) < 0) {
+		perror("[ERROR] Could not start the uhyve monitor event loop.");
+	}
+}
+
+/**
+ * \brief Initializes the uhyve monitor and starts the event  loop
+ */
+void
+uhyve_monitor_init(void)
+{
+	// did we already initialize?
+	if (uhyve_monitor_initialized)
+		return;
+
+	fprintf(stderr, "[INFO] Initializing the uhyve monitor ...\n");
+
+	// install the signal handler for checkpointing
+	// TODO: enable 'live' checkpointing and avoid the interrruption of the
+	//       main thread
+	struct sigaction sa;
+	memset(&sa, 0x00, sizeof(sa));
+	sa.sa_handler = &uhyve_monitor_checkpoint_handler;
+	sigaction(SIGCHKP, &sa, NULL);
+	sem_init(&chk_sem, 0, 0);
+
+	// setup libevent to suppor threading
+	if (evthread_use_pthreads() < 0) {
+		err(1, "[ERROR] Could not enable thread support for libevent.");
+	}
+
+	// create the event base
+	if ((uhyve_monitor_event.evbase = event_base_new()) == 0) {
+		err(1, "[ERROR] Could not initialize libevent.");
+	}
+
+	// initialize the event socket
+	uhyve_monitor_init_evconnlistener();
+
+	// start the event loop
+	if (pthread_create(
+		&uhyve_monitor_thread, NULL, uhyve_monitor_event_loop, NULL)) {
+		err(1, "[ERROR] Could not create the uhyve monitor event loop");
+	}
+
+	uhyve_monitor_initialized = 1;
+}
+
+/**
+ * \brief Frees monitor-related resources
+ */
+void
+uhyve_monitor_destroy(void)
+{
+	// did we initialize the monitor?
+	if (!uhyve_monitor_initialized)
+		return;
+
+	fprintf(stderr, "[INFO] Shutting down  the uhyve monitor ...\n");
+
+	// close the uhyve monitor socket
+	close(uhyve_monitor_sock.sock);
+
+	// cleanup socket path
+	unlink(UHYVE_SOCK_PATH);
+
+	// exit the loop
+	if (event_base_loopexit(uhyve_monitor_event.evbase, NULL) < 0) {
+		err(1, "[ERROR] Could not exit the event loop.");
+	}
+
+	// wait for the monitor thread
+	pthread_join(uhyve_monitor_thread, NULL);
+}

--- a/uhyve-monitor.h
+++ b/uhyve-monitor.h
@@ -1,0 +1,38 @@
+#ifndef __UHYVE_MONITOR_H__
+/*
+ * Copyright (c) 2018, Simon Pickartz, RWTH Aachen University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of the University nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @author Simon Pickartz
+ * @file tools/uhyve-monitor.h
+ * @brief Monitor-related functions
+ */
+
+#define __UHYVE_MONITOR_H__
+void uhyve_monitor_init(void);
+void uhyve_monitor_destroy(void);
+#endif /* __UHYVE_MONITOR_H__ */

--- a/uhyve.c
+++ b/uhyve.c
@@ -64,8 +64,10 @@
 #include <linux/kvm.h>
 
 #include "uhyve.h"
+#include "uhyve-checkpoint.h"
 #include "uhyve-syscalls.h"
 #include "uhyve-migration.h"
+#include "uhyve-monitor.h"
 #include "uhyve-net.h"
 #include "uhyve-gdb.h"
 #include "proxy.h"
@@ -78,7 +80,7 @@ static pthread_mutex_t kvm_lock = PTHREAD_MUTEX_INITIALIZER;
 
 extern bool verbose;
 
-static char* guest_path = NULL;
+char* guest_path = NULL;
 static bool uhyve_gdb_enabled = false;
 size_t guest_size = 0x20000000ULL;
 bool full_checkpoint = false;
@@ -96,6 +98,7 @@ __thread struct kvm_run *run = NULL;
 __thread int vcpufd = -1;
 __thread uint32_t cpuid = 0;
 static sem_t net_sem;
+sem_t monitor_sem;
 sem_t mig_sem;
 
 int uhyve_argc = -1;
@@ -175,6 +178,8 @@ static void close_fd(int* fd)
 static void uhyve_exit(void* arg)
 {
 	//print_registers();
+
+	uhyve_monitor_destroy();
 
 	if (pthread_mutex_trylock(&kvm_lock))
 	{
@@ -592,14 +597,6 @@ static int vcpu_init(void)
 	return 0;
 }
 
-static void sigusr_handler(int signum)
-{
-	pthread_barrier_wait(&barrier);
-	write_cpu_state();
-
-	pthread_barrier_wait(&barrier);
-}
-
 static void vcpu_thread_mig_handler(int signum)
 {
 	/* memory should be allocated at this point */
@@ -629,7 +626,7 @@ static void* uhyve_thread(void* arg)
 
 	/* install signal handler for checkpoint */
 	memset(&sa, 0x00, sizeof(sa));
-	sa.sa_handler = &sigusr_handler;
+	sa.sa_handler = &vcpu_thread_chk_handler;
 	sigaction(SIGTHRCHKP, &sa, NULL);
 
 	/* install signal handler for migration */
@@ -678,9 +675,32 @@ void sigterm_handler(int signum)
 	pthread_exit(0);
 }
 
-int uhyve_init(char *path)
+
+// TODO: support dynamic adaptations during runtime
+int
+uhyve_allocate_vcpus(uint32_t ncores)
 {
-	FILE *f = NULL;
+	if (vcpu_threads)
+		free(vcpu_threads);
+
+	vcpu_threads = (pthread_t *)calloc(ncores, sizeof(pthread_t));
+	if (!vcpu_threads)
+		return -1;
+
+	if (vcpu_fds)
+		free(vcpu_fds);
+
+	vcpu_fds = (int *)calloc(ncores, sizeof(int));
+	if (!vcpu_fds)
+		return -1;
+
+	return 0;
+}
+
+int
+uhyve_init(char *path)
+{
+	FILE *f    = NULL;
 	guest_path = path;
 
 	signal(SIGTERM, sigterm_handler);
@@ -689,6 +709,7 @@ int uhyve_init(char *path)
 	atexit(uhyve_atexit);
 
 	const char *start_mig_server = getenv("HERMIT_MIGRATION_SERVER");
+	const char *start_uhyve_monitor = getenv("HERMIT_MONITOR");
 
 	/*
 	 * Three startups
@@ -696,7 +717,13 @@ int uhyve_init(char *path)
 	 * b) load existing checkpoint
 	 * c) normal run
 	 */
- 	if (start_mig_server) {
+	if (start_uhyve_monitor) {
+		// initialize the semaphore
+		sem_init(&monitor_sem, 0, 0);
+
+		// create the monitor thread
+		uhyve_monitor_init();
+	} else if (start_mig_server) {
 		migration = true;
 		migration_metadata_t metadata;
 		wait_for_incomming_migration(&metadata, MIGRATION_PORT);
@@ -705,23 +732,15 @@ int uhyve_init(char *path)
 		guest_size = metadata.guest_size;
 		elf_entry = metadata.elf_entry;
 		full_checkpoint = metadata.full_checkpoint;
-	} else if ((f = fopen("checkpoint/chk_config.txt", "r")) != NULL) {
-		int tmp = 0;
+	} else if (load_checkpoint_config("checkpoint") == 0) {
 		restart = true;
-
-		fscanf(f, "number of cores: %u\n", &ncores);
-		fscanf(f, "memory size: 0x%zx\n", &guest_size);
-		fscanf(f, "checkpoint number: %u\n", &no_checkpoint);
-		fscanf(f, "entry point: 0x%zx", &elf_entry);
-		fscanf(f, "full checkpoint: %d", &tmp);
-		full_checkpoint = tmp ? true : false;
 
 		if (verbose)
 			fprintf(stderr,
-				"Restart from checkpoint %u "
+				"Restart '%s' from checkpoint %u "
 				"(ncores %d, mem size 0x%zx)\n",
+				guest_path,
 				no_checkpoint, ncores, guest_size);
-		fclose(f);
 	} else {
 		const char* hermit_memory = getenv("HERMIT_MEM");
 		if (hermit_memory)
@@ -736,13 +755,10 @@ int uhyve_init(char *path)
 			full_checkpoint = true;
 	}
 
-	vcpu_threads = (pthread_t*) calloc(ncores, sizeof(pthread_t));
-	if (!vcpu_threads)
-		err(1, "Not enough memory");
-
-	vcpu_fds = (int*) calloc(ncores, sizeof(int));
-	if (!vcpu_fds)
-		err(1, "Not enough memory");
+	if (uhyve_allocate_vcpus(ncores) < 0) {
+		fprintf(stderr, "[ERROR] Could not allocate memory for VCPU data structures. Abort!");
+		exit(EXIT_FAILURE);
+	}
 
 	kvm = open("/dev/kvm", O_RDWR | O_CLOEXEC);
 	if (kvm < 0)
@@ -757,13 +773,20 @@ int uhyve_init(char *path)
 	vmfd = kvm_ioctl(kvm, KVM_CREATE_VM, 0);
 
 #ifdef __x86_64__
-	init_kvm_arch();
+	// the monitor takes care of initializing kvm
+	if (!start_uhyve_monitor || (path != NULL))
+		init_kvm_arch();
+
+	// TODO: revise start-up logic
 	if (restart) {
-		if (load_checkpoint(guest_mem, path) != 0)
+		if (restore_checkpoint("checkpoint") != 0)
 			exit(EXIT_FAILURE);
 	} else if (start_mig_server) {
 		load_migration_data(guest_mem);
 		close_migration_channel();
+	} else if (start_uhyve_monitor && (path == 0)) {
+		// wait for uhyve-monitor command
+		sem_wait(&monitor_sem);
 	} else {
 		if (load_kernel(guest_mem, path) != 0)
 			exit(EXIT_FAILURE);
@@ -840,31 +863,33 @@ int uhyve_loop(int argc, char **argv)
 
 		/* start migration thread; handles SIGUSR1 */
 		pthread_t sig_thr_id;
-		pthread_create (&sig_thr_id, NULL, migration_handler,  (void *)&signal_mask);
-
-		/* install signal handler for migration */
-		struct sigaction sa;
-		memset(&sa, 0x00, sizeof(sa));
-		sa.sa_handler = &vcpu_thread_mig_handler;
-		sigaction(SIGTHRMIG, &sa, NULL);
-
-		/* install eventfd and semaphore for memory mapping requests */
-		struct kvm_irqfd irqfd = {};
-
-		fprintf(stderr, "[INFO] Creating eventfd for migration "
-				"requests\n");
-		if ((mig_efd = eventfd(0, 0)) < 0) {
-			fprintf(stderr, "[WARNING] Could create the migration "
-					"eventfd - %d (%s).\n",
-					errno,
-					strerror(errno));
-		}
-		irqfd.fd = mig_efd;
-		irqfd.gsi = UHYVE_IRQ_MIGRATION;
-		kvm_ioctl(vmfd, KVM_IRQFD, &irqfd);
-		sem_init(&mig_sem, 0, 0);
+		pthread_create (&sig_thr_id, NULL, migration_handler_thread,  (void *)&signal_mask);
 	}
 
+	// TODO: refactor the following code
+	//       this is used for old interface (ENV variables)
+	//       and the uhyve-monitork
+	/* install signal handler for migration */
+	struct sigaction sa;
+	memset(&sa, 0x00, sizeof(sa));
+	sa.sa_handler = &vcpu_thread_mig_handler;
+	sigaction(SIGTHRMIG, &sa, NULL);
+
+	// install eventfd and semaphore for memory mapping requests
+	struct kvm_irqfd irqfd = {};
+
+	fprintf(stderr, "[INFO] Creating eventfd for migration "
+			"requests\n");
+	if ((mig_efd = eventfd(0, 0)) < 0) {
+		fprintf(stderr, "[WARNING] Could create the migration "
+				"eventfd - %d (%s).\n",
+				errno,
+				strerror(errno));
+	}
+	irqfd.fd = mig_efd;
+	irqfd.gsi = UHYVE_IRQ_MIGRATION;
+	kvm_ioctl(vmfd, KVM_IRQFD, &irqfd);
+	sem_init(&mig_sem, 0, 0);
 
 	// First CPU is special because it will boot the system. Other CPUs will
 	// be booted linearily after the first one.


### PR DESCRIPTION
The monitor supports the management of a running uyve instance via a
UNIX socket. Currently supported operations:

* start an application
* create a checkpoint
* load a checkpoint
* migrate a uhyve instance to a remote node

The legacy interfaces for checkpointing and migration are still
supported if the monitor is not activated via the HERMIT_MONITOR
environment variable.

The [uhyve-client](https://github.com/spickartz/uhyve-client) is a small tool that implements the interface for the communication with the uhyve-monitor.